### PR TITLE
root: update wp-browser-version to 3.1.3 to support pslam

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "cache/integration-tests": "0.17.0",
         "codeception/codeception": "4.1.29",
         "fakerphp/faker": "^1.0.0-stable",
-        "lucatume/wp-browser": "3.0.22",
+        "lucatume/wp-browser": "3.1.3",
         "nyholm/psr7": "^1.0.0",
         "phpunit/phpunit": "9.5.13",
         "symplify/monorepo-builder": "9.4.70",

--- a/monorepo-builder.php
+++ b/monorepo-builder.php
@@ -24,6 +24,7 @@ return static function (ContainerConfigurator $containerConfigurator) :void {
             'codeception/codeception' => '4.1.29',
             'symplify/monorepo-builder' => '9.4.70',
             'vlucas/phpdotenv' => '5.4.1',
+            'lucatume/wp-browser' => '3.1.3',
         ],
         ComposerJsonSection::AUTHORS => [
             [

--- a/src/Snicco/Component/better-wp-hooks/composer.json
+++ b/src/Snicco/Component/better-wp-hooks/composer.json
@@ -13,7 +13,7 @@
         "sniccowp/scopable-wp": "dev-master"
     },
     "require-dev": {
-        "lucatume/wp-browser": "3.0.22",
+        "lucatume/wp-browser": "3.1.3",
         "phpunit/phpunit": "9.5.13"
     },
     "autoload": {

--- a/src/Snicco/Component/eloquent/composer.json
+++ b/src/Snicco/Component/eloquent/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "fakerphp/faker": "^1.0.0-stable",
         "phpunit/phpunit": "9.5.13",
-        "lucatume/wp-browser": "3.0.22",
+        "lucatume/wp-browser": "3.1.3",
         "sniccowp/str-arr": "dev-master"
     },
     "autoload": {

--- a/src/Snicco/Component/scopable-wp/composer.json
+++ b/src/Snicco/Component/scopable-wp/composer.json
@@ -18,7 +18,7 @@
         }
     },
     "require-dev": {
-        "lucatume/wp-browser": "3.0.22",
+        "lucatume/wp-browser": "3.1.3",
         "phpunit/phpunit": "9.5.13"
     },
     "autoload-dev": {

--- a/src/Snicco/Component/wp-object-cache-psr16/composer.json
+++ b/src/Snicco/Component/wp-object-cache-psr16/composer.json
@@ -15,7 +15,7 @@
     },
     "require-dev": {
         "cache/integration-tests": "0.17.0",
-        "lucatume/wp-browser": "3.0.22",
+        "lucatume/wp-browser": "3.1.3",
         "phpunit/phpunit": "9.5.13"
     },
     "autoload": {


### PR DESCRIPTION
see: https://github.com/lucatume/wp-browser/pull/561