### PR TITLE
component/http-routing: make RouteConditionFactory.php an interface.

### DIFF
--- a/src/Snicco/Bundle/http-routing/src/HttpRoutingBundle.php
+++ b/src/Snicco/Bundle/http-routing/src/HttpRoutingBundle.php
@@ -171,11 +171,12 @@ final class HttpRoutingBundle implements Bundle
             );
 
             return new Router(
-                $container,
                 $context,
                 $loader,
                 $cache,
-                $admin_area
+                $admin_area,
+                null,
+                null,
             );
         });
     }

--- a/src/Snicco/Component/http-routing/src/Routing/Condition/NewableRouteConditionFactory.php
+++ b/src/Snicco/Component/http-routing/src/Routing/Condition/NewableRouteConditionFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace Snicco\Component\HttpRouting\Routing\Condition;
+
+use function array_values;
+
+final class NewableRouteConditionFactory implements RouteConditionFactory
+{
+    public function __invoke(ConditionBlueprint $blueprint): RouteCondition
+    {
+        $class = $blueprint->class;
+        $args = $blueprint->passed_args;
+
+        /** @psalm-suppress UnsafeInstantiation */
+        $instance = new $class(...array_values($args));
+
+        if ($blueprint->is_negated) {
+            return new NegatedRouteCondition($instance);
+        }
+        return $instance;
+    }
+}

--- a/src/Snicco/Component/http-routing/src/Routing/Condition/RouteConditionFactory.php
+++ b/src/Snicco/Component/http-routing/src/Routing/Condition/RouteConditionFactory.php
@@ -4,64 +4,8 @@ declare(strict_types=1);
 
 namespace Snicco\Component\HttpRouting\Routing\Condition;
 
-use Closure;
-use LogicException;
-use Psr\Container\ContainerExceptionInterface;
-use Psr\Container\ContainerInterface;
-use Psr\Container\NotFoundExceptionInterface;
-use ReflectionClass;
-use ReflectionException;
-
-/**
- * @interal
- * @psalm-internal Snicco\Component\HttpRouting
- */
-final class RouteConditionFactory
+interface RouteConditionFactory
 {
-
-    private ContainerInterface $container;
-
-    public function __construct(ContainerInterface $container)
-    {
-        $this->container = $container;
-    }
-
-    /**
-     * @throws ContainerExceptionInterface
-     * @throws NotFoundExceptionInterface
-     * @throws ReflectionException
-     * @psalm-suppress MixedAssignment
-     */
-    public function create(ConditionBlueprint $blueprint): RouteCondition
-    {
-        $class = $blueprint->class;
-        $args = $blueprint->passed_args;
-
-        try {
-            $instance = $this->container->get($class);
-            if ($instance instanceof Closure) {
-                $instance = $instance(...array_values($args));
-            }
-            if (!$instance instanceof RouteCondition) {
-                throw new LogicException(
-                    sprintf(
-                        "Resolving a route condition from the container must return an instance of [%s].\nGot [%s]",
-                        RouteCondition::class,
-                        is_object($instance) ? get_class($instance) : gettype($instance)
-                    )
-                );
-            }
-        } catch (NotFoundExceptionInterface $e) {
-            // Don't check if the entry is in the container with has since many DI-containers
-            // are capable of constructing the service with auto-wiring.
-            $instance = (new ReflectionClass($class))->newInstanceArgs(array_values($args));
-        }
-
-        if ($blueprint->is_negated) {
-            return new NegatedRouteCondition($instance);
-        }
-
-        return $instance;
-    }
+    public function __invoke(ConditionBlueprint $blueprint): RouteCondition;
 
 }

--- a/src/Snicco/Component/http-routing/src/Routing/UrlMatcher/FastRouteDispatcher.php
+++ b/src/Snicco/Component/http-routing/src/Routing/UrlMatcher/FastRouteDispatcher.php
@@ -230,7 +230,7 @@ final class FastRouteDispatcher implements UrlMatcher
 
         $args = [];
         foreach ($route->getConditions() as $blueprint) {
-            $instance = $this->condition_factory->create($blueprint);
+            $instance = ($this->condition_factory)($blueprint);
 
             if (!$instance->isSatisfied($request)) {
                 return false;

--- a/src/Snicco/Component/http-routing/tests/HttpRunnerTestCase.php
+++ b/src/Snicco/Component/http-routing/tests/HttpRunnerTestCase.php
@@ -263,7 +263,6 @@ abstract class HttpRunnerTestCase extends TestCase
         UrlGenerationContext $context = null
     ): Router {
         $routing = new Router(
-            $this->psr_container,
             $context ?: new UrlGenerationContext($this->app_domain),
             $loader ?: $this->nullLoader(),
             $cache ?: new NullCache(),

--- a/src/Snicco/Component/http-routing/tests/Routing/RouterTest.php
+++ b/src/Snicco/Component/http-routing/tests/Routing/RouterTest.php
@@ -6,7 +6,6 @@ declare(strict_types=1);
 namespace Snicco\Component\HttpRouting\Tests\Routing;
 
 use PHPUnit\Framework\TestCase;
-use Pimple\Container;
 use Snicco\Component\HttpRouting\Routing\Admin\AdminMenu;
 use Snicco\Component\HttpRouting\Routing\Route\Routes;
 use Snicco\Component\HttpRouting\Routing\RouteLoader\DefaultRouteLoadingOptions;
@@ -27,7 +26,6 @@ final class RouterTest extends TestCase
     public function test_url_matcher_is_singleton(): void
     {
         $routing = new Router(
-            new \Pimple\Psr11\Container(new Container()),
             new UrlGenerationContext('127.0.0.1'),
             new PHPFileRouteLoader(
                 [dirname(__DIR__) . '/fixtures/routes'],
@@ -48,7 +46,6 @@ final class RouterTest extends TestCase
     public function test_url_generator_is_singleton(): void
     {
         $routing = new Router(
-            new \Pimple\Psr11\Container(new Container()),
             new UrlGenerationContext('127.0.0.1')
             ,
             new PHPFileRouteLoader(
@@ -70,7 +67,6 @@ final class RouterTest extends TestCase
     public function test_routes_is_singleton(): void
     {
         $routing = new Router(
-            new \Pimple\Psr11\Container(new Container()),
             new UrlGenerationContext('127.0.0.1'),
             new PHPFileRouteLoader(
                 [dirname(__DIR__) . '/fixtures/routes'],
@@ -91,7 +87,6 @@ final class RouterTest extends TestCase
     public function test_admin_menu_is_singleton(): void
     {
         $routing = new Router(
-            new \Pimple\Psr11\Container(new Container()),
             new UrlGenerationContext('127.0.0.1'),
             new PHPFileRouteLoader(
                 [dirname(__DIR__) . '/fixtures/routes'],

--- a/src/Snicco/Component/http-routing/tests/Routing/UrlMatcher/RouteActionDependencyInjectionTest.php
+++ b/src/Snicco/Component/http-routing/tests/Routing/UrlMatcher/RouteActionDependencyInjectionTest.php
@@ -6,7 +6,7 @@ namespace Snicco\Component\HttpRouting\Tests\Routing\UrlMatcher;
 
 use Snicco\Component\HttpRouting\Http\Psr7\Request;
 use Snicco\Component\HttpRouting\Routing\RoutingConfigurator\WebRoutingConfigurator;
-use Snicco\Component\HttpRouting\Tests\fixtures\Conditions\RouteConditionWithDependency;
+use Snicco\Component\HttpRouting\Tests\fixtures\Conditions\RouteConditionWithArgs;
 use Snicco\Component\HttpRouting\Tests\fixtures\Controller\ControllerWithDependencies;
 use Snicco\Component\HttpRouting\Tests\fixtures\Controller\RoutingTestController;
 use Snicco\Component\HttpRouting\Tests\fixtures\TestDependencies\Foo;
@@ -91,33 +91,19 @@ class RouteActionDependencyInjectionTest extends HttpRunnerTestCase
 
     /**
      * @test
-     * @psalm-suppress MixedArgument
      */
     public function arguments_from_conditions_are_passed_after_class_dependencies(): void
     {
-        $foo = new Foo();
-        $foo->value = 'FOO_CONFIG';
-        $this->pimple[Foo::class] = fn(): Foo => $foo;
-
-        $this->pimple[RouteConditionWithDependency::class] = $this->pimple->protect(
-            function (bool $pass): RouteConditionWithDependency {
-                return new RouteConditionWithDependency(
-                    $this->pimple[Foo::class],
-                    $pass
-                );
-            }
-        );
-
         $this->webRouting(function (WebRoutingConfigurator $configurator) {
             $configurator->get(
                 'r1',
                 'teams/{team}/{player}',
                 [RoutingTestController::class, 'requestParamsConditionArgs']
-            )->condition(RouteConditionWithDependency::class, true);
+            )->condition(RouteConditionWithArgs::class, 'FOO', true);
         });
 
         $request = $this->frontendRequest('/teams/dortmund/calvin');
-        $this->assertResponseBody('dortmund:calvin:FOO_CONFIG', $request);
+        $this->assertResponseBody('dortmund:calvin:FOO', $request);
     }
 
 }

--- a/src/Snicco/Component/http-routing/tests/fixtures/Conditions/RouteConditionWithArgs.php
+++ b/src/Snicco/Component/http-routing/tests/fixtures/Conditions/RouteConditionWithArgs.php
@@ -6,17 +6,16 @@ namespace Snicco\Component\HttpRouting\Tests\fixtures\Conditions;
 
 use Snicco\Component\HttpRouting\Http\Psr7\Request;
 use Snicco\Component\HttpRouting\Routing\Condition\RouteCondition;
-use Snicco\Component\HttpRouting\Tests\fixtures\TestDependencies\Foo;
 
-class RouteConditionWithDependency extends RouteCondition
+class RouteConditionWithArgs extends RouteCondition
 {
 
     private bool $make_it_pass;
-    private Foo $foo;
+    private string $val;
 
-    public function __construct(Foo $foo, bool $make_it_pass)
+    public function __construct(string $val, bool $make_it_pass)
     {
-        $this->foo = $foo;
+        $this->val = $val;
         $this->make_it_pass = $make_it_pass;
     }
 
@@ -27,7 +26,7 @@ class RouteConditionWithDependency extends RouteCondition
 
     public function getArguments(Request $request): array
     {
-        return ['foo' => $this->foo->value];
+        return ['condition_arg' => $this->val];
     }
 
 }


### PR DESCRIPTION
The Router class now accepts an optional interface for the RouteConditionFactory.php. The Router now has the correct dependencies instead of relying on a psr container instance.

If resolving conditions via a psr 3 container is desired this can be implemented in user land.