### PR TITLE
component/http-routing: tests for missing todos

### DIFF
--- a/src/Snicco/Bridge/signed-url-middleware/tests/ValidateSignatureTest.php
+++ b/src/Snicco/Bridge/signed-url-middleware/tests/ValidateSignatureTest.php
@@ -53,7 +53,7 @@ final class ValidateSignatureTest extends MiddlewareTestCase
         $response = $this->runMiddleware($m, $request);
 
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertOk();
+        $response->assertableResponse()->assertOk();
     }
 
     /**
@@ -107,11 +107,11 @@ final class ValidateSignatureTest extends MiddlewareTestCase
 
         $response = $this->runMiddleware($m, $request);
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertStatus(200);
+        $response->assertableResponse()->assertStatus(200);
 
         $response = $this->runMiddleware($m, $request);
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertStatus(200);
+        $response->assertableResponse()->assertStatus(200);
 
         $this->expectException(SignedUrlUsageExceeded::class);
         $this->expectExceptionMessage('path [/foo]');
@@ -137,11 +137,11 @@ final class ValidateSignatureTest extends MiddlewareTestCase
         $new_request = $this->frontendRequest($link->asString())->withHeader('User-Agent', 'bar');
 
         // User agent header matches
-        $this->runMiddleware($m, $new_request->withHeader('User-Agent', 'foo'))->psr()->assertOk();
+        $this->runMiddleware($m, $new_request->withHeader('User-Agent', 'foo'))->assertableResponse()->assertOk();
 
         $this->expectException(InvalidSignature::class);
         // User agent header did not match
-        $this->runMiddleware($m, $new_request)->psr()->assertForbidden();
+        $this->runMiddleware($m, $new_request)->assertableResponse()->assertForbidden();
     }
 
     /**
@@ -161,13 +161,13 @@ final class ValidateSignatureTest extends MiddlewareTestCase
 
         $response = $this->runMiddleware($m, $request);
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertOk();
+        $response->assertableResponse()->assertOk();
 
         $request = $this->frontendRequest($link->asString(), [], 'POST');
 
         $response = $this->runMiddleware($m, $request);
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertOk();
+        $response->assertableResponse()->assertOk();
 
         $this->expectException(InvalidSignature::class);
 
@@ -179,7 +179,7 @@ final class ValidateSignatureTest extends MiddlewareTestCase
 
         $response = $this->runMiddleware($m, $request);
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertOk();
+        $response->assertableResponse()->assertOk();
     }
 
     /**
@@ -199,13 +199,13 @@ final class ValidateSignatureTest extends MiddlewareTestCase
 
         $response = $this->runMiddleware($m, $request);
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertOk();
+        $response->assertableResponse()->assertOk();
 
         $request = $this->frontendRequest($link->asString(), [], 'PUT');
 
         $response = $this->runMiddleware($m, $request);
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertOk();
+        $response->assertableResponse()->assertOk();
 
         $this->expectException(InvalidSignature::class);
 
@@ -217,7 +217,7 @@ final class ValidateSignatureTest extends MiddlewareTestCase
 
         $response = $this->runMiddleware($m, $request);
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertOk();
+        $response->assertableResponse()->assertOk();
     }
 
     /**
@@ -237,13 +237,13 @@ final class ValidateSignatureTest extends MiddlewareTestCase
 
         $response = $this->runMiddleware($m, $request);
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertOk();
+        $response->assertableResponse()->assertOk();
 
         $request = $this->frontendRequest($link->asString(), [], 'PATCH');
 
         $response = $this->runMiddleware($m, $request);
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertOk();
+        $response->assertableResponse()->assertOk();
 
         $this->expectException(InvalidSignature::class);
 
@@ -255,7 +255,7 @@ final class ValidateSignatureTest extends MiddlewareTestCase
 
         $response = $this->runMiddleware($m, $request);
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertOk();
+        $response->assertableResponse()->assertOk();
     }
 
     /**
@@ -275,13 +275,13 @@ final class ValidateSignatureTest extends MiddlewareTestCase
 
         $response = $this->runMiddleware($m, $request);
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertOk();
+        $response->assertableResponse()->assertOk();
 
         $request = $this->frontendRequest($link->asString(), [], 'DELETE');
 
         $response = $this->runMiddleware($m, $request);
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertOk();
+        $response->assertableResponse()->assertOk();
 
         $this->expectException(InvalidSignature::class);
 
@@ -293,7 +293,7 @@ final class ValidateSignatureTest extends MiddlewareTestCase
 
         $response = $this->runMiddleware($m, $request);
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertOk();
+        $response->assertableResponse()->assertOk();
     }
 
 }

--- a/src/Snicco/Bundle/session/tests/Middleware/SessionNoCacheTest.php
+++ b/src/Snicco/Bundle/session/tests/Middleware/SessionNoCacheTest.php
@@ -21,7 +21,7 @@ final class SessionNoCacheTest extends MiddlewareTestCase
         $response = $this->runMiddleware($middleware, $this->frontendRequest());
 
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertHeader('cache-control', 'max-age=0, must-revalidate, private');
+        $response->assertableResponse()->assertHeader('cache-control', 'max-age=0, must-revalidate, private');
     }
 
 }

--- a/src/Snicco/Bundle/session/tests/Middleware/ShareSessionWithViewsTest.php
+++ b/src/Snicco/Bundle/session/tests/Middleware/ShareSessionWithViewsTest.php
@@ -59,7 +59,7 @@ final class ShareSessionWithViewsTest extends MiddlewareTestCase
         $response = $this->runMiddleware($middleware, $this->request_with_session);
         $response->assertNextMiddlewareCalled();
 
-        $view_response = $response->psr()->getPsrResponse();
+        $view_response = $response->assertableResponse()->getPsrResponse();
         $this->assertInstanceOf(ViewResponse::class, $view_response);
 
         $this->assertEquals([

--- a/src/Snicco/Bundle/session/tests/Middleware/StatefulRequestTest.php
+++ b/src/Snicco/Bundle/session/tests/Middleware/StatefulRequestTest.php
@@ -191,7 +191,7 @@ final class StatefulRequestTest extends MiddlewareTestCase
         $response = $this->runMiddleware($m, $this->frontendRequest('/foo', [], 'POST'));
         $response->assertNextMiddlewareCalled();
 
-        $response = $response->psr()->getPsrResponse();
+        $response = $response->assertableResponse()->getPsrResponse();
         $cookies = $response->cookies();
 
         $headers = $cookies->toHeaders();
@@ -218,7 +218,7 @@ final class StatefulRequestTest extends MiddlewareTestCase
 
         $response = $this->runMiddleware($this->getMiddleware(), $request_with_cookie);
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertHeader('X-FOO', 'bar');
+        $response->assertableResponse()->assertHeader('X-FOO', 'bar');
     }
 
     /**
@@ -232,7 +232,7 @@ final class StatefulRequestTest extends MiddlewareTestCase
 
         $response = $this->runMiddleware($this->getMiddleware(), $this->frontendRequest());
 
-        $response = $response->psr()->getPsrResponse();
+        $response = $response->assertableResponse()->getPsrResponse();
         $cookies = $response->cookies();
 
         $headers = $cookies->toHeaders();

--- a/src/Snicco/Component/http-routing/testing/AssertableCookie.php
+++ b/src/Snicco/Component/http-routing/testing/AssertableCookie.php
@@ -28,7 +28,6 @@ final class AssertableCookie
 
     public string $same_site = '';
 
-    // @todo this needs a test
     public function __construct(string $set_cookie_header)
     {
         $parts = explode('; ', $set_cookie_header);

--- a/src/Snicco/Component/http-routing/testing/MiddlewareTestCase.php
+++ b/src/Snicco/Component/http-routing/testing/MiddlewareTestCase.php
@@ -94,7 +94,7 @@ abstract class MiddlewareTestCase extends TestCase
         $this->next_middleware_response = $closure;
     }
 
-    final protected function runMiddleware(MiddlewareInterface $middleware, Request $request): MiddlewareTestResponse
+    final protected function runMiddleware(MiddlewareInterface $middleware, Request $request): MiddlewareTestResult
     {
         $this->next_called = false;
         $this->received_request_by_next_middleware = null;
@@ -124,7 +124,7 @@ abstract class MiddlewareTestCase extends TestCase
         /** @var Response $response */
         $response = $middleware->process($request, $this->next());
 
-        return new MiddlewareTestResponse(
+        return new MiddlewareTestResult(
             $response,
             $this->next_called
         );

--- a/src/Snicco/Component/http-routing/testing/MiddlewareTestResult.php
+++ b/src/Snicco/Component/http-routing/testing/MiddlewareTestResult.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\Assert as PHPUnit;
 use Psr\Http\Message\ResponseInterface;
 use Snicco\Component\HttpRouting\Http\Psr7\Response;
 
-final class MiddlewareTestResponse
+final class MiddlewareTestResult
 {
 
     private bool $next_middleware_called;
@@ -17,24 +17,23 @@ final class MiddlewareTestResponse
     public function __construct(ResponseInterface $response, bool $next_called = false)
     {
         $this->next_middleware_called = $next_called;
-        // @todo this needs a test
         $response = $response instanceof Response ? $response : new Response($response);
         $this->response = new AssertableResponse($response);
     }
 
-    public function assertNextMiddlewareCalled(): MiddlewareTestResponse
+    public function assertNextMiddlewareCalled(): MiddlewareTestResult
     {
         PHPUnit::assertTrue($this->next_middleware_called, 'The next middleware was not called.');
         return $this;
     }
 
-    public function assertNextMiddlewareNotCalled(): MiddlewareTestResponse
+    public function assertNextMiddlewareNotCalled(): MiddlewareTestResult
     {
         PHPUnit::assertFalse($this->next_middleware_called, 'The next middleware was called.');
         return $this;
     }
 
-    public function psr(): AssertableResponse
+    public function assertableResponse(): AssertableResponse
     {
         return $this->response;
     }

--- a/src/Snicco/Component/http-routing/tests/Testing/AssertableCookieTest.php
+++ b/src/Snicco/Component/http-routing/tests/Testing/AssertableCookieTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace Snicco\Component\HttpRouting\Tests\Testing;
+
+use PHPUnit\Framework\TestCase;
+use Snicco\Component\HttpRouting\Testing\AssertableCookie;
+
+final class AssertableCookieTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function test_cookie_header_is_parsed_correctly(): void
+    {
+        $cookie = new AssertableCookie(
+            'foo=bar; Path=/; Expires=Thu, 01-Jan-2024 00:00:01 GMT; SameSite=Lax; Secure; HostOnly; HttpOnly'
+        );
+
+        $this->assertSame('bar', $cookie->value);
+        $this->assertSame('/', $cookie->path);
+        $this->assertSame('Thu, 01-Jan-2024 00:00:01 GMT', $cookie->expires);
+        $this->assertSame('Lax', $cookie->same_site);
+        $this->assertSame(true, $cookie->secure);
+        $this->assertSame(true, $cookie->http_only);
+    }
+}

--- a/src/Snicco/Middleware/default-headers/tests/DefaultHeadersTest.php
+++ b/src/Snicco/Middleware/default-headers/tests/DefaultHeadersTest.php
@@ -23,8 +23,8 @@ class DefaultHeadersTest extends MiddlewareTestCase
 
         $response->assertNextMiddlewareCalled();
 
-        $response->psr()->assertHeader('foo', 'bar');
-        $response->psr()->assertHeader('baz', 'biz');
+        $response->assertableResponse()->assertHeader('foo', 'bar');
+        $response->assertableResponse()->assertHeader('baz', 'biz');
     }
 
     /**
@@ -42,7 +42,7 @@ class DefaultHeadersTest extends MiddlewareTestCase
         );
         $response->assertNextMiddlewareCalled();
 
-        $response->psr()->assertHeader('foo', 'bar');
+        $response->assertableResponse()->assertHeader('foo', 'bar');
     }
 
 }

--- a/src/Snicco/Middleware/https-only/tests/HttpsOnlyTest.php
+++ b/src/Snicco/Middleware/https-only/tests/HttpsOnlyTest.php
@@ -22,7 +22,7 @@ final class HttpsOnlyTest extends MiddlewareTestCase
         $response = $this->runMiddleware($middleware, $request);
 
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertOk();
+        $response->assertableResponse()->assertOk();
     }
 
     /**
@@ -37,7 +37,7 @@ final class HttpsOnlyTest extends MiddlewareTestCase
         $response = $this->runMiddleware($middleware, $request);
 
         $response->assertNextMiddlewareNotCalled();
-        $response->psr()->assertRedirect('https://foobar.com/foo/bar', 301);
+        $response->assertableResponse()->assertRedirect('https://foobar.com/foo/bar', 301);
     }
 
     /**
@@ -52,7 +52,7 @@ final class HttpsOnlyTest extends MiddlewareTestCase
         $response = $this->runMiddleware($middleware, $request);
 
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertOk();
+        $response->assertableResponse()->assertOk();
     }
 
 }

--- a/src/Snicco/Middleware/must-match-route/tests/MustMatchRouteTest.php
+++ b/src/Snicco/Middleware/must-match-route/tests/MustMatchRouteTest.php
@@ -43,7 +43,7 @@ final class MustMatchRouteTest extends MiddlewareTestCase
 
         $response = $this->runMiddleware($middleware, $this->frontendRequest());
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertOk();
+        $response->assertableResponse()->assertOk();
     }
 
 }

--- a/src/Snicco/Middleware/negotiation/tests/NegotiateContentTest.php
+++ b/src/Snicco/Middleware/negotiation/tests/NegotiateContentTest.php
@@ -33,8 +33,8 @@ final class NegotiateContentTest extends MiddlewareTestCase
         $response = $this->runMiddleware($middleware, $request);
 
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertSeeText('text/html');
-        $response->psr()->assertHeader('content-type', 'text/html; charset=UTF-8');
+        $response->assertableResponse()->assertSeeText('text/html');
+        $response->assertableResponse()->assertHeader('content-type', 'text/html; charset=UTF-8');
 
         $request = $this->frontendRequest()->withHeader(
             'accept',
@@ -44,9 +44,9 @@ final class NegotiateContentTest extends MiddlewareTestCase
         $response = $this->runMiddleware($middleware, $request);
 
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertSeeText('application/json');
-        $response->psr()->assertHeader('content-type', 'application/json; charset=UTF-8');
-        $response->psr()->assertHeader('content-language', 'en');
+        $response->assertableResponse()->assertSeeText('application/json');
+        $response->assertableResponse()->assertHeader('content-type', 'application/json; charset=UTF-8');
+        $response->assertableResponse()->assertHeader('content-language', 'en');
     }
 
     /**

--- a/src/Snicco/Middleware/no-robots/tests/NoRobotsTest.php
+++ b/src/Snicco/Middleware/no-robots/tests/NoRobotsTest.php
@@ -20,7 +20,7 @@ class NoRobotsTest extends MiddlewareTestCase
         $response = $this->runMiddleware($middleware, $this->frontendRequest());
 
         $response->assertNextMiddlewareCalled();
-        $header = $response->psr()->getHeader('X-Robots-Tag');
+        $header = $response->assertableResponse()->getHeader('X-Robots-Tag');
 
         $this->assertContains('noindex', $header);
         $this->assertContains('nofollow', $header);
@@ -37,7 +37,7 @@ class NoRobotsTest extends MiddlewareTestCase
         $response = $this->runMiddleware($middleware, $this->frontendRequest());
 
         $response->assertNextMiddlewareCalled();
-        $header = $response->psr()->getHeader('X-Robots-Tag');
+        $header = $response->assertableResponse()->getHeader('X-Robots-Tag');
 
         $this->assertNotContains('noindex', $header);
         $this->assertContains('nofollow', $header);
@@ -54,7 +54,7 @@ class NoRobotsTest extends MiddlewareTestCase
         $response = $this->runMiddleware($middleware, $this->frontendRequest());
 
         $response->assertNextMiddlewareCalled();
-        $header = $response->psr()->getHeader('X-Robots-Tag');
+        $header = $response->assertableResponse()->getHeader('X-Robots-Tag');
 
         $this->assertContains('noindex', $header);
         $this->assertNotContains('nofollow', $header);
@@ -71,7 +71,7 @@ class NoRobotsTest extends MiddlewareTestCase
         $response = $this->runMiddleware($middleware, $this->frontendRequest());
 
         $response->assertNextMiddlewareCalled();
-        $header = $response->psr()->getPsrResponse()->getHeader('X-Robots-Tag');
+        $header = $response->assertableResponse()->getPsrResponse()->getHeader('X-Robots-Tag');
 
         $this->assertContains('noindex', $header);
         $this->assertContains('nofollow', $header);

--- a/src/Snicco/Middleware/open-redirect-protection/tests/OpenRedirectProtectionTest.php
+++ b/src/Snicco/Middleware/open-redirect-protection/tests/OpenRedirectProtectionTest.php
@@ -21,7 +21,7 @@ class OpenRedirectProtectionTest extends MiddlewareTestCase
         $response = $this->runMiddleware($this->newMiddleware(), $request);
 
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertOk();
+        $response->assertableResponse()->assertOk();
     }
 
     /**
@@ -38,7 +38,7 @@ class OpenRedirectProtectionTest extends MiddlewareTestCase
         $response = $this->runMiddleware($this->newMiddleware(), $request);
 
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertRedirect('/foo', 302);
+        $response->assertableResponse()->assertRedirect('/foo', 302);
     }
 
     /**
@@ -55,7 +55,7 @@ class OpenRedirectProtectionTest extends MiddlewareTestCase
         $response = $this->runMiddleware($this->newMiddleware(), $request);
 
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertRedirect('https://foo.com/bar', 302);
+        $response->assertableResponse()->assertRedirect('https://foo.com/bar', 302);
     }
 
     /**
@@ -71,7 +71,7 @@ class OpenRedirectProtectionTest extends MiddlewareTestCase
         $response = $this->runMiddleware($this->newMiddleware(), $request);
 
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertLocation('/exit?intended_redirect=https://bar.com/foo');
+        $response->assertableResponse()->assertLocation('/exit?intended_redirect=https://bar.com/foo');
     }
 
     /**
@@ -87,7 +87,7 @@ class OpenRedirectProtectionTest extends MiddlewareTestCase
         $response = $this->runMiddleware($this->newMiddleware(), $request);
 
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertLocation('/exit?intended_redirect=//bar.com:80/path/info');
+        $response->assertableResponse()->assertLocation('/exit?intended_redirect=//bar.com:80/path/info');
     }
 
     /**
@@ -103,7 +103,7 @@ class OpenRedirectProtectionTest extends MiddlewareTestCase
         $response = $this->runMiddleware($this->newMiddleware(['stripe.com']), $request);
 
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertRedirect('https://stripe.com/foo');
+        $response->assertableResponse()->assertRedirect('https://stripe.com/foo');
     }
 
     /**
@@ -120,7 +120,7 @@ class OpenRedirectProtectionTest extends MiddlewareTestCase
         $response = $this->runMiddleware($this->newMiddleware(['stripe.com']), $request);
 
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertLocation('/exit?intended_redirect=https://paypal.com/pay');
+        $response->assertableResponse()->assertLocation('/exit?intended_redirect=https://paypal.com/pay');
     }
 
     /**
@@ -138,7 +138,7 @@ class OpenRedirectProtectionTest extends MiddlewareTestCase
         $response = $this->runMiddleware($this->newMiddleware(['*.stripe.com']), $request);
 
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertRedirect('https://payments.stripe.com/foo');
+        $response->assertableResponse()->assertRedirect('https://payments.stripe.com/foo');
 
         $this->withNextMiddlewareResponse(function () {
             return $this->responseFactory()->redirect(
@@ -150,7 +150,7 @@ class OpenRedirectProtectionTest extends MiddlewareTestCase
         $response = $this->runMiddleware($this->newMiddleware(['*.stripe.com']), $request);
 
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertRedirect('https://accounts.stripe.com/foo');
+        $response->assertableResponse()->assertRedirect('https://accounts.stripe.com/foo');
     }
 
     /**
@@ -169,7 +169,7 @@ class OpenRedirectProtectionTest extends MiddlewareTestCase
         $response = $this->runMiddleware($this->newMiddleware(), $request);
 
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertRedirect('https://accounts.foo.com/foo');
+        $response->assertableResponse()->assertRedirect('https://accounts.foo.com/foo');
     }
 
     /**
@@ -187,7 +187,7 @@ class OpenRedirectProtectionTest extends MiddlewareTestCase
 
         $response = $this->runMiddleware($this->newMiddleware(), $request);
 
-        $response->psr()->assertRedirect('https://external-site.com');
+        $response->assertableResponse()->assertRedirect('https://external-site.com');
     }
 
     /**
@@ -206,7 +206,7 @@ class OpenRedirectProtectionTest extends MiddlewareTestCase
         $response = $this->runMiddleware($this->newMiddleware(['stripe.com'], '/exit_page/'), $request);
 
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertRedirect('/exit_page/?intended_redirect=https://paypal.com/pay');
+        $response->assertableResponse()->assertRedirect('/exit_page/?intended_redirect=https://paypal.com/pay');
     }
 
     /**

--- a/src/Snicco/Middleware/redirect/tests/RedirectTest.php
+++ b/src/Snicco/Middleware/redirect/tests/RedirectTest.php
@@ -25,7 +25,7 @@ class RedirectTest extends MiddlewareTestCase
         $response = $this->runMiddleware($middleware, $this->frontendRequest('/foo'));
 
         $response->assertNextMiddlewareNotCalled();
-        $response->psr()->assertRedirect('/bar')->assertStatus(301);
+        $response->assertableResponse()->assertRedirect('/bar')->assertStatus(301);
     }
 
     /**
@@ -40,7 +40,7 @@ class RedirectTest extends MiddlewareTestCase
         ]);
 
         $response = $this->runMiddleware($middleware, $this->frontendRequest('/foo/'));
-        $response->psr()->assertRedirect('https://foobar.com/foo')->assertStatus(301);
+        $response->assertableResponse()->assertRedirect('https://foobar.com/foo')->assertStatus(301);
     }
 
     /**
@@ -57,7 +57,7 @@ class RedirectTest extends MiddlewareTestCase
         $response = $this->runMiddleware($middleware, $this->frontendRequest('/bogus'));
 
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertOk();
+        $response->assertableResponse()->assertOk();
     }
 
     /**
@@ -79,13 +79,13 @@ class RedirectTest extends MiddlewareTestCase
         ]);
 
         $response = $this->runMiddleware($middleware, $this->frontendRequest('/foo'));
-        $response->psr()->assertRedirect('/bar', 301);
+        $response->assertableResponse()->assertRedirect('/bar', 301);
 
         $response = $this->runMiddleware($middleware, $this->frontendRequest('/baz'));
-        $response->psr()->assertRedirect('/biz', 302);
+        $response->assertableResponse()->assertRedirect('/biz', 302);
 
         $response = $this->runMiddleware($middleware, $this->frontendRequest('/boo'));
-        $response->psr()->assertRedirect('/bam/', 307);
+        $response->assertableResponse()->assertRedirect('/bam/', 307);
     }
 
     /**
@@ -101,11 +101,11 @@ class RedirectTest extends MiddlewareTestCase
         ]);
 
         $response = $this->runMiddleware($middleware, $this->frontendRequest('/foo?page=60'));
-        $response->psr()->assertRedirect('/bar')->assertStatus(301);
+        $response->assertableResponse()->assertRedirect('/bar')->assertStatus(301);
         $response->assertNextMiddlewareNotCalled();
 
         $response = $this->runMiddleware($middleware, $this->frontendRequest('/foo?page=50'));
-        $response->psr()->assertOk();
+        $response->assertableResponse()->assertOk();
         $response->assertNextMiddlewareCalled();
     }
 
@@ -122,10 +122,10 @@ class RedirectTest extends MiddlewareTestCase
         ]);
 
         $response = $this->runMiddleware($middleware, $this->frontendRequest('/foo/bar?page=60'));
-        $response->psr()->assertRedirect('/baz')->assertStatus(301);
+        $response->assertableResponse()->assertRedirect('/baz')->assertStatus(301);
 
         $response = $this->runMiddleware($middleware, $this->frontendRequest('/foo/bar?baz=biz'));
-        $response->psr()->assertRedirect('/baz')->assertStatus(301);
+        $response->assertableResponse()->assertRedirect('/baz')->assertStatus(301);
     }
 
     /**
@@ -141,10 +141,10 @@ class RedirectTest extends MiddlewareTestCase
         ]);
 
         $response = $this->runMiddleware($middleware, $this->frontendRequest('/foo'));
-        $response->psr()->assertRedirect('/bar', 301);
+        $response->assertableResponse()->assertRedirect('/bar', 301);
 
         $response = $this->runMiddleware($middleware, $this->frontendRequest('/baz'));
-        $response->psr()->assertRedirect('/bar', 301);
+        $response->assertableResponse()->assertRedirect('/bar', 301);
     }
 
     /**

--- a/src/Snicco/Middleware/share-cookies/tests/ShareCookiesTest.php
+++ b/src/Snicco/Middleware/share-cookies/tests/ShareCookiesTest.php
@@ -27,7 +27,7 @@ class ShareCookiesTest extends MiddlewareTestCase
         );
 
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertHeader(
+        $response->assertableResponse()->assertHeader(
             'Set-Cookie',
             'foo=bar; Path=/; SameSite=Lax; Secure; HostOnly; HttpOnly'
         );
@@ -51,7 +51,7 @@ class ShareCookiesTest extends MiddlewareTestCase
             $this->frontendRequest()
         );
 
-        $cookie_header = $response->psr()->getHeader('Set-Cookie');
+        $cookie_header = $response->assertableResponse()->getHeader('Set-Cookie');
 
         $this->assertSame(
             'foo=bar; Path=/; SameSite=Lax; Secure; HostOnly; HttpOnly',
@@ -77,7 +77,7 @@ class ShareCookiesTest extends MiddlewareTestCase
             $this->frontendRequest()
         );
 
-        $cookie_header = $response->psr()->getHeader('Set-Cookie');
+        $cookie_header = $response->assertableResponse()->getHeader('Set-Cookie');
         $this->assertSame(
             'foo=deleted; Path=/; Expires=Thu, 01-Jan-1970 00:00:01 GMT; SameSite=Lax; Secure; HostOnly; HttpOnly',
             $cookie_header[0]
@@ -95,7 +95,7 @@ class ShareCookiesTest extends MiddlewareTestCase
         );
 
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertHeaderMissing('set-cookie');
+        $response->assertableResponse()->assertHeaderMissing('set-cookie');
     }
 
 }

--- a/src/Snicco/Middleware/trailing-slash/tests/TrailingSlashTest.php
+++ b/src/Snicco/Middleware/trailing-slash/tests/TrailingSlashTest.php
@@ -21,10 +21,10 @@ class TrailingSlashTest extends MiddlewareTestCase
         $response = $this->runMiddleware(new TrailingSlash(true), $request);
 
         $response->assertNextMiddlewareNotCalled();
-        $response->psr()->assertRedirect();
-        $response->psr()->assertStatus(301);
+        $response->assertableResponse()->assertRedirect();
+        $response->assertableResponse()->assertStatus(301);
 
-        $response->psr()->assertRedirectPath('/bar/');
+        $response->assertableResponse()->assertRedirectPath('/bar/');
     }
 
     /**
@@ -37,7 +37,7 @@ class TrailingSlashTest extends MiddlewareTestCase
         $response = $this->runMiddleware(new TrailingSlash(true), $request);
 
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertOk();
+        $response->assertableResponse()->assertOk();
     }
 
     /**
@@ -50,7 +50,7 @@ class TrailingSlashTest extends MiddlewareTestCase
         $response = $this->runMiddleware(new TrailingSlash(false), $request);
 
         $response->assertNextMiddlewareNotCalled();
-        $response->psr()->assertRedirectPath('/bar')->assertStatus(301);
+        $response->assertableResponse()->assertRedirectPath('/bar')->assertStatus(301);
     }
 
     /**
@@ -63,7 +63,7 @@ class TrailingSlashTest extends MiddlewareTestCase
         $response = $this->runMiddleware(new TrailingSlash(false), $request);
 
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertOk();
+        $response->assertableResponse()->assertOk();
     }
 
     /**
@@ -75,11 +75,11 @@ class TrailingSlashTest extends MiddlewareTestCase
 
         $response = $this->runMiddleware(new TrailingSlash(false), $request);
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertOk();
+        $response->assertableResponse()->assertOk();
 
         $response = $this->runMiddleware(new TrailingSlash(true), $request);
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertOk();
+        $response->assertableResponse()->assertOk();
     }
 
     /**
@@ -91,11 +91,11 @@ class TrailingSlashTest extends MiddlewareTestCase
 
         $response = $this->runMiddleware(new TrailingSlash(false), new Request($request));
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertOk();
+        $response->assertableResponse()->assertOk();
 
         $response = $this->runMiddleware(new TrailingSlash(true), new Request($request));
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertOk();
+        $response->assertableResponse()->assertOk();
     }
 
 }

--- a/src/Snicco/Middleware/wp-guests-only/tests/GuestsOnlyTest.php
+++ b/src/Snicco/Middleware/wp-guests-only/tests/GuestsOnlyTest.php
@@ -26,7 +26,7 @@ class GuestsOnlyTest extends MiddlewareTestCase
         $response = $this->runMiddleware($this->newMiddleware($wp), $this->frontendRequest());
 
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertOk();
+        $response->assertableResponse()->assertOk();
     }
 
     /**
@@ -41,7 +41,7 @@ class GuestsOnlyTest extends MiddlewareTestCase
 
         $response = $this->runMiddleware($this->newMiddleware($wp), $this->frontendRequest());
 
-        $response->psr()->assertRedirect('/dashboard');
+        $response->assertableResponse()->assertRedirect('/dashboard');
         $response->assertNextMiddlewareNotCalled();
     }
 
@@ -57,7 +57,7 @@ class GuestsOnlyTest extends MiddlewareTestCase
 
         $response = $this->runMiddleware($this->newMiddleware($wp), $this->frontendRequest());
 
-        $response->psr()->assertRedirect('/home');
+        $response->assertableResponse()->assertRedirect('/home');
         $response->assertNextMiddlewareNotCalled();
     }
 
@@ -70,7 +70,7 @@ class GuestsOnlyTest extends MiddlewareTestCase
 
         $response = $this->runMiddleware($this->newMiddleware($wp), $this->frontendRequest());
 
-        $response->psr()->assertRedirect('/');
+        $response->assertableResponse()->assertRedirect('/');
         $response->assertNextMiddlewareNotCalled();
     }
 
@@ -84,7 +84,7 @@ class GuestsOnlyTest extends MiddlewareTestCase
             $this->frontendRequest()
         );
 
-        $response->psr()->assertRedirect('/custom-home-page');
+        $response->assertableResponse()->assertRedirect('/custom-home-page');
         $response->assertNextMiddlewareNotCalled();
     }
 
@@ -99,7 +99,7 @@ class GuestsOnlyTest extends MiddlewareTestCase
         );
 
         $response->assertNextMiddlewareNotCalled();
-        $psr_response = $response->psr();
+        $psr_response = $response->assertableResponse();
         $psr_response->assertIsJson();
         $psr_response->assertBodyExact(
             json_encode(['message' => 'You are already authenticated'], JSON_THROW_ON_ERROR)
@@ -118,7 +118,7 @@ class GuestsOnlyTest extends MiddlewareTestCase
         );
 
         $response->assertNextMiddlewareNotCalled();
-        $psr_response = $response->psr();
+        $psr_response = $response->assertableResponse();
         $psr_response->assertIsJson();
         $psr_response->assertBodyExact(
             json_encode(['message' => 'Guests only'], JSON_THROW_ON_ERROR)

--- a/src/Snicco/Middleware/wp-nonce/tests/VerifyWPNonceTest.php
+++ b/src/Snicco/Middleware/wp-nonce/tests/VerifyWPNonceTest.php
@@ -30,7 +30,7 @@ final class VerifyWPNonceTest extends MiddlewareTestCase
 
         $response = $this->runMiddleware($middleware, $request);
         $response->assertNextMiddlewareCalled();
-        $response->psr()->assertOk();
+        $response->assertableResponse()->assertOk();
     }
 
     /**
@@ -66,7 +66,7 @@ final class VerifyWPNonceTest extends MiddlewareTestCase
         $response = $this->runMiddleware($middleware, $request);
         $response->assertNextMiddlewareCalled();
 
-        $psr = $response->psr()->getPsrResponse();
+        $psr = $response->assertableResponse()->getPsrResponse();
         $this->assertInstanceOf(ViewResponse::class, $psr);
 
         $data = $psr->viewData();
@@ -89,7 +89,7 @@ final class VerifyWPNonceTest extends MiddlewareTestCase
         $request = $this->frontendRequest('/foo');
 
         $response = $this->runMiddleware($middleware, $request);
-        $psr = $response->psr()->getPsrResponse();
+        $psr = $response->assertableResponse()->getPsrResponse();
         $this->assertInstanceOf(ViewResponse::class, $psr);
 
         $data = $psr->viewData();
@@ -114,7 +114,7 @@ final class VerifyWPNonceTest extends MiddlewareTestCase
             ])
         );
 
-        $response->assertNextMiddlewareCalled()->psr()->assertOk();
+        $response->assertNextMiddlewareCalled()->assertableResponse()->assertOk();
     }
 
     /**
@@ -135,7 +135,7 @@ final class VerifyWPNonceTest extends MiddlewareTestCase
         $request = $this->frontendRequest('/foo');
 
         $response = $this->runMiddleware($middleware, $request);
-        $psr = $response->psr()->getPsrResponse();
+        $psr = $response->assertableResponse()->getPsrResponse();
         $this->assertInstanceOf(ViewResponse::class, $psr);
 
         $data = $psr->viewData();
@@ -160,7 +160,7 @@ final class VerifyWPNonceTest extends MiddlewareTestCase
             ])
         );
 
-        $response->assertNextMiddlewareCalled()->psr()->assertOk();
+        $response->assertNextMiddlewareCalled()->assertableResponse()->assertOk();
     }
 
     /**
@@ -177,7 +177,7 @@ final class VerifyWPNonceTest extends MiddlewareTestCase
         $request = $this->frontendRequest('/foo');
 
         $response = $this->runMiddleware($middleware, $request);
-        $psr = $response->psr()->getPsrResponse();
+        $psr = $response->assertableResponse()->getPsrResponse();
         $this->assertInstanceOf(ViewResponse::class, $psr);
 
         $data = $psr->viewData();
@@ -202,7 +202,7 @@ final class VerifyWPNonceTest extends MiddlewareTestCase
             ])
         );
 
-        $response->assertNextMiddlewareCalled()->psr()->assertOk();
+        $response->assertNextMiddlewareCalled()->assertableResponse()->assertOk();
     }
 
     /**
@@ -217,7 +217,7 @@ final class VerifyWPNonceTest extends MiddlewareTestCase
         });
 
         $response = $this->runMiddleware($middleware, $this->frontendRequest('/foo'));
-        $response->assertNextMiddlewareCalled()->psr()->assertOk();
+        $response->assertNextMiddlewareCalled()->assertableResponse()->assertOk();
     }
 
 }


### PR DESCRIPTION
MiddlewareTestResponse.php is now named MiddlewareTestResult.php