### PR TITLE
chore(root): Run workflows conditionally based on changed files

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -11,14 +11,45 @@ env:
   COMPOSER_ROOT_VERSION: "dev-master"
 
 jobs:
-  code_analysis:
+  changes:
+    name: Filter path for tests
     runs-on: ubuntu-20.04
+    outputs:
+      php: ${{ steps.filter.outputs.php }}
+      composer: ${{ steps.filter.outputs.composer }}
+      deptrac: ${{ steps.filter.outputs.composer }}
+      psalm: ${{ steps.filter.outputs.psalm }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Filter changed paths
+        uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            php:
+              - 'src/**/*.php'
+              - 'tests/**/*.php'
+              - 'bin/*.php'
+            composer:
+              - 'composer.json'
+            deptrac:
+              - 'deptrac/**'
+            plsam:
+              - 'psalm.xml'
+              - 'psalm/**'
+
+  code_analysis:
     name: ${{ matrix.actions.name }}
+    needs: changes
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
         actions:
           - name: 'Deptrac'
+            should_run: ${{ needs.changes.outputs.php == 'true' || needs.changes.outputs.deptrac == 'true' }}
             run: |
               curl -LS https://github.com/qossmic/deptrac/releases/download/0.19.3/deptrac.phar -o deptrac.phar
               sudo chmod +x deptrac.phar
@@ -26,6 +57,7 @@ jobs:
               composer deptrac -- --formatter=github-actions
 
           - name: 'Composer require checker'
+            should_run: ${{ needs.changes.outputs.php == 'true' || needs.changes.outputs.composer == 'true' }}
             run: |
               curl -LS https://github.com/maglnet/ComposerRequireChecker/releases/download/3.8.0/composer-require-checker.phar -o require-checker.phar
               sudo chmod +x require-checker.phar
@@ -33,6 +65,7 @@ jobs:
               require-checker check composer.json --config-file=$GITHUB_WORKSPACE/composer-require-checker.json
 
           - name: 'Composer unused'
+            should_run: ${{ needs.changes.outputs.php == 'true' || needs.changes.outputs.composer == 'true' }}
             run: |
               curl -LS https://github.com/composer-unused/composer-unused/releases/download/0.7.12/composer-unused.phar -o composer-unused.phar
               sudo chmod +x composer-unused.phar
@@ -40,22 +73,30 @@ jobs:
               composer-unused
 
           - name: 'Composer Validate'
+            should_run: ${{ needs.changes.outputs.php == 'true' || needs.changes.outputs.composer == 'true' }}
             run: composer validate
 
           - name: 'Psalm'
+            should_run: ${{ needs.changes.outputs.php == 'true' || needs.changes.outputs.psalm == 'true' }}
             run: composer psalm -- --shepherd --stats
 
+    # The value of matrix.actions.should_run is (bool) true. Not (string) true as in the matrix.
     steps:
       - name: 'Checkout repo'
+        if: ${{ matrix.actions.should_run == true || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
         uses: actions/checkout@v2
 
       - name: 'Setup PHP'
+        if: ${{ matrix.actions.should_run == true || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
         uses: shivammathur/setup-php@v2
         with:
           php-version: 7.4
           coverage: none
 
       - name: 'Install dependencies'
+        if: ${{ matrix.actions.should_run == true || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
         uses: ramsey/composer-install@v1
 
-      - run: ${{ matrix.actions.run }}
+      - name: ${{ matrix.actions.name }}
+        if: ${{ matrix.actions.should_run == true || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+        run: ${{ matrix.actions.run }}

--- a/.github/workflows/code_coverage.yaml
+++ b/.github/workflows/code_coverage.yaml
@@ -12,9 +12,29 @@ env:
 
 jobs:
 
+  changes:
+    name: Filter path for tests
+    runs-on: ubuntu-20.04
+    outputs:
+      coverage: ${{ steps.filter.outputs.coverage }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Filter changed paths
+        uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            coverage:
+              - 'src/**/*.php'
+              - 'codecov.yml'
+  
+
   unit_tests_coverage:
 
     name: Unit Tests Coverage
+    needs: changes
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
@@ -24,9 +44,11 @@ jobs:
 
     steps:
       - name: Checkout code
+        if: ${{ needs.changes.outputs.coverage == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'}}
         uses: actions/checkout@v2
 
       - name: Setup PHP [${{ matrix.php }}]
+        if: ${{ needs.changes.outputs.coverage == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'}}
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
@@ -37,29 +59,34 @@ jobs:
           fail-fast: true
 
       - name: Install composer dependencies
+        if: ${{ needs.changes.outputs.coverage == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'}}
         uses: ramsey/composer-install@v1
         with:
           dependency-versions: ${{ matrix.dependencies }}
 
       - name: Run phpunit, testsuite component, middleware and bridge (=> testsuite unit)
+        if: ${{ needs.changes.outputs.coverage == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'}}
         run: |
           composer phpunit:all -- --coverage-clover coverage-phpunit.xml
 
       - name: Archive code coverage results
+        if: ${{ needs.changes.outputs.coverage == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'}}
         uses: actions/upload-artifact@v2
         with:
           name: coverage-phpunit.xml
           path: coverage-phpunit.xml
 
       - name: Upload Code Coverage to Codecov
+        if: ${{ needs.changes.outputs.coverage == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'}}
         run: |
           curl -Os https://uploader.codecov.io/latest/linux/codecov
           chmod +x codecov
           ./codecov -t ${{ secrets.CODECOV_TOKEN }} -f coverage-phpunit.xml -Z
 
-  wordpress_tests_coverage:
 
+  wordpress_tests_coverage:
     name: WordPress Tests Coverage
+    needs: changes
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
@@ -86,9 +113,11 @@ jobs:
 
     steps:
       - name: Checkout code
+        if: ${{ needs.changes.outputs.coverage == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'}}
         uses: actions/checkout@v2
 
       - name: Setup PHP [${{ matrix.php }}]
+        if: ${{ needs.changes.outputs.coverage == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'}}
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
@@ -99,12 +128,14 @@ jobs:
           fail-fast: true
 
       - name: Install composer dependencies
+        if: ${{ needs.changes.outputs.coverage == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'}}
         uses: "ramsey/composer-install@v1"
         with:
           dependency-versions: "${{ matrix.dependencies }}"
 
       # Config value must match the ones in env.testing.dist
       - name: Download WordPress [${{ matrix.wp }}]
+        if: ${{ needs.changes.outputs.coverage == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'}}
         run: |
           mkdir wordpress && cd wordpress
           wp core download --force --skip-content --version=${{ matrix.wp }}
@@ -118,16 +149,20 @@ jobs:
         working-directory: /tmp
 
       - name: Run WordPress tests with codeception
+        if: ${{ needs.changes.outputs.coverage == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'}}
         run: |
           composer codeception:all -- --coverage-xml codeception-coverage.xml
 
+
       - name: Archive code coverage results
+        if: ${{ needs.changes.outputs.coverage == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'}}
         uses: actions/upload-artifact@v2
         with:
           name: codeception-coverage.xml
           path: _output/codeception-coverage.xml
 
       - name: Upload Code Coverage to Codecov
+        if: ${{ needs.changes.outputs.coverage == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'}}
         run: |
           curl -Os https://uploader.codecov.io/latest/linux/codecov
           chmod +x codecov

--- a/.github/workflows/code_coverage.yaml
+++ b/.github/workflows/code_coverage.yaml
@@ -12,29 +12,9 @@ env:
 
 jobs:
 
-  changes:
-    name: Filter path for tests
-    runs-on: ubuntu-20.04
-    outputs:
-      coverage: ${{ steps.filter.outputs.coverage }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Filter changed paths
-        uses: dorny/paths-filter@v2
-        id: filter
-        with:
-          filters: |
-            coverage:
-              - 'src/**/*.php'
-              - 'codecov.yml'
-  
-
   unit_tests_coverage:
 
     name: Unit Tests Coverage
-    needs: changes
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
@@ -44,11 +24,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        if: ${{ needs.changes.outputs.coverage == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'}}
         uses: actions/checkout@v2
 
       - name: Setup PHP [${{ matrix.php }}]
-        if: ${{ needs.changes.outputs.coverage == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'}}
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
@@ -59,25 +37,21 @@ jobs:
           fail-fast: true
 
       - name: Install composer dependencies
-        if: ${{ needs.changes.outputs.coverage == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'}}
         uses: ramsey/composer-install@v1
         with:
           dependency-versions: ${{ matrix.dependencies }}
 
       - name: Run phpunit, testsuite component, middleware and bridge (=> testsuite unit)
-        if: ${{ needs.changes.outputs.coverage == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'}}
         run: |
           composer phpunit:all -- --coverage-clover coverage-phpunit.xml
 
       - name: Archive code coverage results
-        if: ${{ needs.changes.outputs.coverage == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'}}
         uses: actions/upload-artifact@v2
         with:
           name: coverage-phpunit.xml
           path: coverage-phpunit.xml
 
       - name: Upload Code Coverage to Codecov
-        if: ${{ needs.changes.outputs.coverage == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'}}
         run: |
           curl -Os https://uploader.codecov.io/latest/linux/codecov
           chmod +x codecov
@@ -86,7 +60,6 @@ jobs:
 
   wordpress_tests_coverage:
     name: WordPress Tests Coverage
-    needs: changes
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
@@ -113,11 +86,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        if: ${{ needs.changes.outputs.coverage == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'}}
         uses: actions/checkout@v2
 
       - name: Setup PHP [${{ matrix.php }}]
-        if: ${{ needs.changes.outputs.coverage == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'}}
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
@@ -128,14 +99,12 @@ jobs:
           fail-fast: true
 
       - name: Install composer dependencies
-        if: ${{ needs.changes.outputs.coverage == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'}}
         uses: "ramsey/composer-install@v1"
         with:
           dependency-versions: "${{ matrix.dependencies }}"
 
       # Config value must match the ones in env.testing.dist
       - name: Download WordPress [${{ matrix.wp }}]
-        if: ${{ needs.changes.outputs.coverage == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'}}
         run: |
           mkdir wordpress && cd wordpress
           wp core download --force --skip-content --version=${{ matrix.wp }}
@@ -149,20 +118,17 @@ jobs:
         working-directory: /tmp
 
       - name: Run WordPress tests with codeception
-        if: ${{ needs.changes.outputs.coverage == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'}}
         run: |
           composer codeception:all -- --coverage-xml codeception-coverage.xml
 
 
       - name: Archive code coverage results
-        if: ${{ needs.changes.outputs.coverage == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'}}
         uses: actions/upload-artifact@v2
         with:
           name: codeception-coverage.xml
           path: _output/codeception-coverage.xml
 
       - name: Upload Code Coverage to Codecov
-        if: ${{ needs.changes.outputs.coverage == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'}}
         run: |
           curl -Os https://uploader.codecov.io/latest/linux/codecov
           chmod +x codecov

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,9 +12,32 @@ env:
 
 jobs:
 
-  unit_tests:
+  # These jobs are set in the branch protection rules for the master branch. They must run otherwise every PR
+  # will be stuck at "Expected — Waiting for status to be reported ". For this reason we can not use GitHub's native path filters.
+  # It's also not possible to run each job conditionally. The job must run. The only option is to run all steps conditionally.
+  changes:
+    name: Filter path for tests
+    runs-on: ubuntu-20.04
+    outputs:
+      php: ${{ steps.filter.outputs.php }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
 
+      - name: Filter changed paths
+        uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            php:
+              - 'src/**/*.php'
+              - 'tests/**/*.php'
+              - 'phpunit.xml.dist'
+              - 'codeception/*dist.yml'
+
+  unit_tests:
     name: Unit Tests
+    needs: changes
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
@@ -24,9 +47,11 @@ jobs:
 
     steps:
       - name: Checkout code
+        if: ${{ needs.changes.outputs.php == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
         uses: actions/checkout@v2
 
       - name: Setup PHP [${{ matrix.php }}]
+        if: ${{ needs.changes.outputs.php == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
@@ -35,16 +60,18 @@ jobs:
           ini-values: error_reporting=E_ALL
 
       - name: Install composer dependencies
+        if: ${{ needs.changes.outputs.php == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
         uses: ramsey/composer-install@v1
         with:
           dependency-versions: ${{ matrix.dependencies }}
 
       - name: Run phpunit, testsuite unit
+        if: ${{ needs.changes.outputs.php == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
         run: composer phpunit:all
 
   wordpress_tests:
-
     name: WordPress Tests
+    needs: changes
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
@@ -54,7 +81,6 @@ jobs:
         dependencies: [ lowest, highest ]
 
     services:
-
       mysql:
         image: mysql:8.0.21
         env:
@@ -71,11 +97,12 @@ jobs:
         options: --entrypoint redis-server
 
     steps:
-
       - name: Checkout code
+        if: ${{ needs.changes.outputs.php == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
         uses: actions/checkout@v2
 
       - name: Setup PHP [${{ matrix.php }}]
+        if: ${{ needs.changes.outputs.php == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
@@ -84,12 +111,14 @@ jobs:
           ini-values: error_reporting=E_ALL
 
       - name: Install composer dependencies
+        if: ${{ needs.changes.outputs.php == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
         uses: "ramsey/composer-install@v1"
         with:
           dependency-versions: "${{ matrix.dependencies }}"
 
       # Config value must match the ones in env.testing.dist
       - name: Download WordPress [${{ matrix.wp }}]
+        if: ${{ needs.changes.outputs.php == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
         run: |
           mkdir wordpress && cd wordpress
           wp core download --force --skip-content --version=${{ matrix.wp }}
@@ -103,4 +132,5 @@ jobs:
         working-directory: /tmp
 
       - name: Run WordPress tests with codeception
+        if: ${{ needs.changes.outputs.php == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
         run: composer codeception:all


### PR DESCRIPTION
The time for CI/CD runs became pretty large especially if non-src files like READMEs are changed. This commit modifies the tests, code-analysis, and coverage workflow so that they only run if relevant files are modified. For this, we use the GitHub action https://github.com/dorny/paths-filter. 