### PR TITLE
ci(monorepo): fix yaml syntax in workflows

### DIFF
--- a/.github/workflows/code_coverage.yaml
+++ b/.github/workflows/code_coverage.yaml
@@ -8,9 +8,9 @@ on:
 # from codecov.io
 jobs:
 
-  unit_tests_coverage:
+  phpunit_coverage:
 
-    name: 'Unit Tests Coverage'
+    name: 'PHPUnit coverage'
     runs-on: ubuntu-20.04
 
     steps:
@@ -44,8 +44,8 @@ jobs:
           ./codecov -t ${{ secrets.CODECOV_TOKEN }} -f coverage-phpunit.xml -Z
 
 
-  wordpress_tests_coverage:
-    name: 'WordPress Tests Coverage'
+  codeception_coverage:
+    name: 'Codeception coverage'
     runs-on: ubuntu-20.04
 
     services:

--- a/.github/workflows/psalm.yaml
+++ b/.github/workflows/psalm.yaml
@@ -3,8 +3,9 @@ name: 'Psalm'
 on:
   pull_request:
   push:
-    # psalm needs to run on push to master, otherwise stats will never be sent to shepherd.io
-    - master
+    branches:
+      # psalm needs to run on push to master, otherwise stats will never be sent to shepherd.io
+      - master
 
 jobs:
   psalm:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,11 +39,11 @@ jobs:
         # https://github.com/crazy-max/ghaction-import-gpg/releases/tag/v4.3.0
         uses: crazy-max/ghaction-import-gpg@4d58d49bfefed583addec96996588e8bc4b306b8
         with:
-          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
-          git-user-signingkey: true
-          git-commit-gpgsign: true
-          git-config-global: true
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_config_global: true
 
       - name: 'Disable admin enforcement'
         uses: actions/github-script@v6

--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -63,7 +63,7 @@ jobs:
               sudo mv composer-unused.phar /usr/local/bin/composer-unused
               composer-unused
 
-          - name: 'Composer Validate'
+          - name: 'Composer validate'
             should_run: ${{ needs.diff.outputs.php == 'true' || needs.diff.outputs.composer == 'true' }}
             run: composer validate
 
@@ -87,3 +87,15 @@ jobs:
       - name: ${{ matrix.actions.name }}
         if: ${{ matrix.actions.should_run == true }}
         run: ${{ matrix.actions.run }}
+
+  check_matrix:
+    name: 'Static Analysis'
+    runs-on: ubuntu-20.04
+    needs: static_analysis
+    if: ${{ always() }}
+    steps:
+      - name: 'Check matrix success'
+        if: ${{ needs.static_analysis.result != 'success'}}
+        run: |
+          echo "At least one static analysis tool has failed."
+          exit 1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,7 +8,7 @@ jobs:
   should_run:
     runs-on: ubuntu-20.04
     outputs:
-      true: ${{ steps.get_diff.outputs.php === 'true' }}
+      diff: ${{ steps.get_diff.outputs.php }}
     steps:
       - name: 'Checkout code'
         uses: actions/checkout@v2
@@ -38,11 +38,11 @@ jobs:
     steps:
 
       - name: 'Checkout code'
-        if: needs.should_run.outputs.true
+        if: ${{ needs.should_run.outputs.diff == 'true' }}
         uses: actions/checkout@v2
 
       - name: 'Setup PHP [${{ matrix.php }}]'
-        if: needs.should_run.outputs.true
+        if: ${{ needs.should_run.outputs.diff == 'true' }}
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
@@ -50,13 +50,13 @@ jobs:
           ini-values: error_reporting=E_ALL
 
       - name: 'Install composer dependencies'
-        if: needs.should_run.outputs.true
+        if: ${{ needs.should_run.outputs.diff == 'true' }}
         uses: ramsey/composer-install@v1
         with:
           dependency-versions: ${{ matrix.dependencies }}
 
       - name: 'Run phpunit tests'
-        if: needs.should_run.outputs.true
+        if: ${{ needs.should_run.outputs.diff == 'true' }}
         run: composer phpunit:all
 
   codeception_tests:
@@ -89,11 +89,11 @@ jobs:
     steps:
 
       - name: 'Checkout code'
-        if: needs.should_run.outputs.true
+        if: ${{ needs.should_run.outputs.diff == 'true' }}
         uses: actions/checkout@v2
 
       - name: 'Setup PHP [${{ matrix.php }}]'
-        if: needs.should_run.outputs.true
+        if: ${{ needs.should_run.outputs.diff == 'true' }}
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
@@ -102,14 +102,14 @@ jobs:
           ini-values: error_reporting=E_ALL
 
       - name: 'Install composer dependencies'
-        if: needs.should_run.outputs.true
+        if: ${{ needs.should_run.outputs.diff == 'true' }}
         uses: ramsey/composer-install@v1
         with:
           dependency-versions: ${{ matrix.dependencies }}
 
       # The config values must match the ones in env.testing.dist
       - name: 'Download WordPress [${{ matrix.wp }}]'
-        if: needs.should_run.outputs.true
+        if: ${{ needs.should_run.outputs.diff == 'true' }}
         run: |
           mkdir wordpress && cd wordpress
           wp core download --force --skip-content --version=${{ matrix.wp }}
@@ -123,5 +123,5 @@ jobs:
         working-directory: /tmp
 
       - name: 'Run codeception tests'
-        if: needs.should_run.outputs.true
+        if: ${{ needs.should_run.outputs.diff == 'true' }}
         run: composer codeception:all

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -126,7 +126,7 @@ jobs:
         if: ${{ needs.should_run.outputs.diff == 'true' }}
         run: composer codeception:all
 
-  test_matrix:
+  check_matrix:
     name: 'Tests'
     runs-on: ubuntu-20.04
     needs: [ phpunit_tests, codeception_tests ]

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,7 +25,7 @@ jobs:
               - 'phpunit.xml.dist'
               - 'codeception/*dist.yml'                
 
-  unit_tests:
+  phpunit_tests:
     name: 'PHPUnit tests'
     needs: should_run
     runs-on: ubuntu-20.04
@@ -125,3 +125,20 @@ jobs:
       - name: 'Run codeception tests'
         if: ${{ needs.should_run.outputs.diff == 'true' }}
         run: composer codeception:all
+
+  test_matrix:
+    name: 'Tests'
+    runs-on: ubuntu-20.04
+    needs: [ phpunit_tests, codeception_tests ]
+    if: ${{ always() }}
+    steps:
+      - name: 'Check phpunit tests'
+        if: ${{ needs.phpunit_tests.result != 'success'}}
+        run: |
+          echo "At least one PHPUnit step has failed."
+          exit 1
+      - name: 'Check codeception tests'
+        if: ${{ needs.codeception_tests.result != 'success'}}
+        run: |
+          echo "At least one Codeception step has failed."
+          exit


### PR DESCRIPTION
The release.yaml workflow and the psalm.yaml workflow contained invalid syntax.