### PR TITLE
ci(monorepo): include the testing directory in codecov

### DIFF
--- a/.github/workflows/code_coverage.yaml
+++ b/.github/workflows/code_coverage.yaml
@@ -40,11 +40,14 @@ jobs:
           name: coverage-phpunit.xml
           path: coverage-phpunit.xml
 
-      - name: 'Upload coverage to codecov.io'
-        run: |
-          curl -Os https://uploader.codecov.io/latest/linux/codecov
-          chmod +x codecov
-          ./codecov -t ${{ secrets.CODECOV_TOKEN }} -f coverage-phpunit.xml -Z
+      - name: 'Upload phpunit coverage to codecov.io'
+        # v2.1
+        uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage-phpunit.xml
+          fail_ci_if_error: true
+          verbose: true
 
 
   codeception_coverage:
@@ -106,8 +109,11 @@ jobs:
           name: codeception-coverage.xml
           path: _output/codeception-coverage.xml
 
-      - name: 'Upload coverage to codecov.io'
-        run: |
-          curl -Os https://uploader.codecov.io/latest/linux/codecov
-          chmod +x codecov
-          ./codecov -t ${{ secrets.CODECOV_TOKEN }} -f codeception-coverage.xml -Z
+      - name: 'Upload codeception coverage to codecov.io'
+        # v2.1
+        uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./codeception-coverage.xml
+          fail_ci_if_error: true
+          verbose: true

--- a/.github/workflows/code_coverage.yaml
+++ b/.github/workflows/code_coverage.yaml
@@ -1,6 +1,9 @@
 name: 'Code coverage'
 
 on:
+  push:
+    branches:
+      - master
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/code_coverage.yaml
+++ b/.github/workflows/code_coverage.yaml
@@ -11,9 +11,8 @@ on:
 # from codecov.io
 jobs:
 
-  phpunit_coverage:
-
-    name: 'PHPUnit coverage'
+  collect_phpunit_coverage:
+    name: 'Collect phpunit coverage'
     runs-on: ubuntu-20.04
 
     steps:
@@ -40,18 +39,8 @@ jobs:
           name: coverage-phpunit.xml
           path: coverage-phpunit.xml
 
-      - name: 'Upload phpunit coverage to codecov.io'
-        # v2.1
-        uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage-phpunit.xml
-          fail_ci_if_error: true
-          verbose: true
-
-
-  codeception_coverage:
-    name: 'Codeception coverage'
+  collect_codeception_coverage:
+    name: 'Collect codeception coverage'
     runs-on: ubuntu-20.04
 
     services:
@@ -101,19 +90,31 @@ jobs:
 
       - name: 'Collect codeception coverage'
         run: |
-          composer codeception:all -- --coverage-xml codeception-coverage.xml
+          composer codeception:all -- --coverage-xml coverage-codeception.xml
 
       - name: 'Archive code coverage results'
         uses: actions/upload-artifact@v2
         with:
           name: codeception-coverage.xml
-          path: _output/codeception-coverage.xml
+          path: _output/coverage-codeception.xml
 
-      - name: 'Upload codeception coverage to codecov.io'
+  upload_coverage:
+    name: 'Upload coverage to codecov.io'
+    runs-on: ubuntu-20.04
+    needs: [ collect_phpunit_coverage, collect_codeception_coverage ]
+    steps:
+
+      - name: 'Download coverage from artifacts'
+        uses: actions/download-artifact@v3
+        with:
+          path: coverage-reports
+
+      - name: 'Upload artifacts to codecov.io'
         # v2.1
         uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./codeception-coverage.xml
+          directory: coverage-reports
+          files: coverage-codeception.xml, coverage-phpunit.xml
           fail_ci_if_error: true
           verbose: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -11,10 +11,7 @@ coverage:
         target: auto
         threshold: 0.01%
         paths:
-          - "src/Snicco/Component"
-          - "src/Snicco/Bridge"
-          - "src/Snicco/Middleware"
-          - "src/Snicco/Bundle"
+          - "src/Snicco/*"
         if_not_found: failure
         if_ci_failed: error
 
@@ -24,10 +21,7 @@ coverage:
         target: auto
         threshold: 0.05%
         paths:
-          - "src/Snicco/Component"
-          - "src/Snicco/Bridge"
-          - "src/Snicco/Middleware"
-          - "src/Snicco/Bundle"
+          - "src/Snicco/*"
         if_not_found: failure
         if_ci_failed: error
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,7 @@ codecov:
   require_ci_to_pass: yes
   notify:
     wait_for_ci: yes
-    after_n_builds: 2 # Only send notifications after 2 builds because we upload 2 times currently (1x PHPUnit / 1x Codeception)
+    after_n_builds: 1
 
 coverage:
   status:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,10 +15,7 @@
 >
     <testsuites>
         <testsuite name="unit">
-            <directory suffix="Test.php">src/Snicco/Bridge/*/tests/</directory>
-            <directory suffix="Test.php">src/Snicco/Component/*/tests/</directory>
-            <directory suffix="Test.php">src/Snicco/Middleware/*/tests/</directory>
-            <directory suffix="Test.php">src/Snicco/Bundle/*/tests/</directory>
+            <directory suffix="Test.php">src/Snicco/*/*/tests/</directory>
             <directory suffix="Test.php">tests/Monorepo</directory>
             <exclude>src/Snicco/*/*/tests/integration</exclude>
             <exclude>src/Snicco/*/*/tests/wordpress</exclude>
@@ -46,12 +43,6 @@
             <directory suffix="Test.php">src/Snicco/Bundle/*/tests/</directory>
             <exclude>src/Snicco/Bundle/*/tests/integration</exclude>
             <exclude>src/Snicco/Bundle/*/tests/wordpress</exclude>
-        </testsuite>
-
-        <testsuite name="integration">
-            <directory suffix="Test.php">src/Snicco/Bridge/*/tests/integration</directory>
-            <directory suffix="Test.php">src/Snicco/Component/*/tests/integration</directory>
-            <directory suffix="Test.php">src/Snicco/Middleware/*/tests/integration</directory>
         </testsuite>
 
         <testsuite name="monorepo">


### PR DESCRIPTION
The directories were hardcoded previously
so that merging #101 caused the coverage
for all testing classes to disappear