### PR TITLE
ci(monorepo): disable codecov temporarily

### DIFF
--- a/.github/workflows/code_coverage.yaml
+++ b/.github/workflows/code_coverage.yaml
@@ -1,9 +1,6 @@
 name: 'Code coverage'
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
We need to get a passing commit into master.
Currently, every commit into master will fail
coverage for the same "missing head" reason.