### PR TITLE
ci(monorepo): run code coverage workflow conditionally

### DIFF
--- a/.github/workflows/code_coverage.yaml
+++ b/.github/workflows/code_coverage.yaml
@@ -1,18 +1,39 @@
 name: 'Code coverage'
 
 on:
+  push:
+    branches:
+      - master
   pull_request:
   workflow_dispatch:
 
-# These jobs must always run, otherwise the status check "project" will always be stuck waiting for a response
-# from codecov.io
 jobs:
 
-  phpunit_coverage:
-
-    name: 'PHPUnit coverage'
+  should_run:
+    name: 'Generate diff'
     runs-on: ubuntu-20.04
+    outputs:
+      diff: ${{ steps.get_diff.outputs.php }}
+    steps:
+      - name: 'Checkout code'
+        uses: actions/checkout@v2
 
+      - name: 'Generate diff'
+        # https://github.com/dorny/paths-filter/tree/v2.10.2
+        uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721
+        id: get_diff
+        with:
+          filters: |
+            php:
+              - 'src/Snicco/**/*.php'
+              - 'codecov.yml'
+  
+
+  phpunit_coverage:
+    name: 'PHPUnit coverage'
+    needs: should_run
+    if: ${{ needs.should_run.outputs.diff == 'true' || github.event_name == 'push' || github.event_name  == 'workflow_dispatch' }}
+    runs-on: ubuntu-20.04
     steps:
       - name: 'Checkout code'
         uses: actions/checkout@v2
@@ -49,7 +70,8 @@ jobs:
   codeception_coverage:
     name: 'Codeception coverage'
     runs-on: ubuntu-20.04
-
+    needs: should_run
+    if: ${{ needs.should_run.outputs.diff == 'true' || github.event_name == 'push' || github.event_name  == 'workflow_dispatch' }}
     services:
       mysql:
         image: mysql:8.0.21

--- a/codecov.yml
+++ b/codecov.yml
@@ -16,20 +16,29 @@ coverage:
         threshold: 0.01%
         paths:
           - "src/Snicco/*"
-        if_not_found: failure
+
+        # codecov.io should not fail or PRs if we don't upload coverage.
+        # If this option is set to error we have to upload coverage
+        # for every commit even if no source code changed.
+        if_not_found: success
+
         # codecov.io should only care about its own status.
         # We don't want codecov.io to set its check to error if
         # let's say the commit message linting failed.
         if_ci_failed: success
 
-    # The difference is explained quite vague at https://docs.codecov.com/docs/commit-status#patch-status
     patch:
       default:
         target: auto
         threshold: 0.05%
         paths:
           - "src/Snicco/*"
-        if_not_found: failure
+
+        # codecov.io should not fail or PRs if we don't upload coverage.
+        # If this option is set to error we have to upload coverage
+        # for every commit even if no source code changed.
+        if_not_found: success
+
         # codecov.io should only care about its own status.
         # We don't want codecov.io to set its check to error if
         # let's say the commit message linting failed.


### PR DESCRIPTION
Set if_not_found to false in codecov.yml
This allows as to upload coverage
conditionally only if source code
changed.