### PR TITLE
ci(monorepo): run codecov for all pull requests

### DIFF
--- a/.github/workflows/code_coverage.yaml
+++ b/.github/workflows/code_coverage.yaml
@@ -9,30 +9,8 @@ on:
 
 jobs:
 
-  should_run:
-    name: 'Generate diff'
-    runs-on: ubuntu-20.04
-    outputs:
-      diff: ${{ steps.get_diff.outputs.php }}
-    steps:
-      - name: 'Checkout code'
-        uses: actions/checkout@v2
-
-      - name: 'Generate diff'
-        # https://github.com/dorny/paths-filter/tree/v2.10.2
-        uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721
-        id: get_diff
-        with:
-          filters: |
-            php:
-              - 'src/Snicco/**/*.php'
-              - 'codecov.yml'
-  
-
   phpunit_coverage:
     name: 'PHPUnit coverage'
-    needs: should_run
-    if: ${{ needs.should_run.outputs.diff == 'true' || github.event_name == 'push' || github.event_name  == 'workflow_dispatch' }}
     runs-on: ubuntu-20.04
     steps:
       - name: 'Checkout code'
@@ -70,8 +48,6 @@ jobs:
   codeception_coverage:
     name: 'Codeception coverage'
     runs-on: ubuntu-20.04
-    needs: should_run
-    if: ${{ needs.should_run.outputs.diff == 'true' || github.event_name == 'push' || github.event_name  == 'workflow_dispatch' }}
     services:
       mysql:
         image: mysql:8.0.21

--- a/codecov.yml
+++ b/codecov.yml
@@ -20,7 +20,7 @@ coverage:
         # codecov.io should not fail or PRs if we don't upload coverage.
         # If this option is set to error we have to upload coverage
         # for every commit even if no source code changed.
-        if_not_found: success
+        if_not_found: failure
 
         # codecov.io should only care about its own status.
         # We don't want codecov.io to set its check to error if
@@ -37,7 +37,7 @@ coverage:
         # codecov.io should not fail or PRs if we don't upload coverage.
         # If this option is set to error we have to upload coverage
         # for every commit even if no source code changed.
-        if_not_found: success
+        if_not_found: failure
 
         # codecov.io should only care about its own status.
         # We don't want codecov.io to set its check to error if


### PR DESCRIPTION
Send coverage to codecov.io for all PRs.
After trying every possible configuration
of settings,
it's not worth it to upload conditionally,
as CI status will not be sent back
from codecov.io if no coverage is uploaded.

Fixes: #92
See: https://community.codecov.com/t/how-to-make-codecov-branch-status-checks-conditional/3549