### PR TITLE
fix(*): fix bundle installation docs for composer

### DIFF
--- a/src/Snicco/Bundle/better-wp-cache/README.md
+++ b/src/Snicco/Bundle/better-wp-cache/README.md
@@ -1,4 +1,4 @@
-# Snicco - BetterWPCacheBundle 
+# Snicco - BetterWPCacheBundle
 
 [![codecov](https://img.shields.io/badge/Coverage-100%25-success
 )](https://codecov.io/gh/snicco/snicco)
@@ -12,7 +12,7 @@ This **WordPress** bundle configures the standalone [`snicco/better-wp-cache`](h
 ## Installation
 
 ```shell
-composer install snicco/better-wp-cache-bundle
+composer require snicco/better-wp-cache-bundle
 ```
 
 ## Configuration
@@ -33,12 +33,12 @@ use Snicco\Bundle\BetterWPCache\BetterWPCacheBundle;
 use Snicco\Component\Kernel\ValueObject\Environment;
 
 return [
-    
+
     'bundles' => [
         Environment::ALL => [
             BetterWPCacheBundle::class
-        ]   
-    ]   
+        ]
+    ]
 ];
 
 ```

--- a/src/Snicco/Bundle/better-wp-hooks/README.md
+++ b/src/Snicco/Bundle/better-wp-hooks/README.md
@@ -12,7 +12,7 @@ This **WordPress** bundle configures the standalone [`snicco/better-wp-hooks`](h
 ## Installation
 
 ```shell
-composer install snicco/better-wp-hooks-bundle
+composer require snicco/better-wp-hooks-bundle
 ```
 
 ## Configuration
@@ -31,12 +31,12 @@ use Snicco\Bundle\BetterWPHooks\BetterWPHooksBundle;
 use Snicco\Component\Kernel\ValueObject\Environment;
 
 return [
-    
+
     'bundles' => [
         Environment::ALL => [
             BetterWPHooksBundle::class
-        ]   
-    ]   
+        ]
+    ]
 ];
 
 ```
@@ -63,7 +63,7 @@ var_dump($event_dispatcher === $psr_event_dispatcher); // true
 $event_mapper = $kernel->container()->make(EventMapper::class);
 ```
 
-If the [`snicco/event-dispatcher-testing`](https://github.com/snicco/event-dispatcher-testing) package is installed 
+If the [`snicco/event-dispatcher-testing`](https://github.com/snicco/event-dispatcher-testing) package is installed
 a [`TestableEventDispatcher`](https://github.com/snicco/event-dispatcher-testing) will automatically be used in the testing environment.
 
 ## Contributing

--- a/src/Snicco/Bundle/better-wp-mail/README.md
+++ b/src/Snicco/Bundle/better-wp-mail/README.md
@@ -12,7 +12,7 @@ This **WordPress** bundle configures the standalone [`snicco/better-wp-mail`](ht
 ## Installation
 
 ```shell
-composer install snicco/better-wp-mail-bundle
+composer require snicco/better-wp-mail-bundle
 ```
 
 ## Configuration
@@ -33,12 +33,12 @@ Add the [`BetterWPMailBundle`](src/BetterWPMailBundle.php) to your `bundles.php`
 use Snicco\Bundle\BetterWPMail\BetterWPMailBundle;
 
 return [
-    
+
     'bundles' => [
         Snicco\Component\Kernel\ValueObject\Environment::ALL => [
             BetterWPMailBundle::class
-        ]   
-    ]   
+        ]
+    ]
 ];
 
 ```

--- a/src/Snicco/Bundle/better-wpdb/README.md
+++ b/src/Snicco/Bundle/better-wpdb/README.md
@@ -12,7 +12,7 @@ This **WordPress** bundle configures the standalone [`snicco/better-wpdb`](https
 ## Installation
 
 ```shell
-composer install snicco/better-wpdb-bundle
+composer require snicco/better-wpdb-bundle
 ```
 
 ## Configuration
@@ -30,12 +30,12 @@ Add the [`BetterWPDBBundle`](src/BetterWPDBBundle.php) to your `bundles.php` con
 use Snicco\Bundle\BetterWPDB\BetterWPDBBundle;
 
 return [
-    
+
     'bundles' => [
         Snicco\Component\Kernel\ValueObject\Environment::ALL => [
             BetterWPDBBundle::class
-        ]   
-    ]   
+        ]
+    ]
 ];
 
 ```

--- a/src/Snicco/Bundle/blade/README.md
+++ b/src/Snicco/Bundle/blade/README.md
@@ -12,7 +12,7 @@ This **WordPress** bundle configures the standalone [`snicco/blade-bridge`](http
 ## Installation
 
 ```shell
-composer install snicco/blade-bundle
+composer require snicco/blade-bundle
 ```
 
 ## Configuration
@@ -32,13 +32,13 @@ use Snicco\Bundle\Blade\BladeBundle;
 use Snicco\Bundle\Templating\TemplatingBundle;
 
 return [
-    
+
     'bundles' => [
         Snicco\Component\Kernel\ValueObject\Environment::ALL => [
             TemplatingBundle::class,
             BladeBundle::class
-        ]   
-    ]   
+        ]
+    ]
 ];
 
 ```

--- a/src/Snicco/Bundle/debug/README.md
+++ b/src/Snicco/Bundle/debug/README.md
@@ -16,7 +16,7 @@ The DebugBundle configures [`Whoops`](https://github.com/filp/whoops) as the err
 ## Installation
 
 ```shell
-composer install snicco/debug-bundle
+composer require snicco/debug-bundle
 ```
 
 ## Configuration
@@ -38,12 +38,12 @@ config file **in the DEV environment**.
 use Snicco\Bundle\Debug\DebugBundle;
 
 return [
-    
+
     'bundles' => [
         Snicco\Component\Kernel\ValueObject\Environment::DEV => [
            DebugBundle::class
-        ]   
-    ]   
+        ]
+    ]
 ];
 
 ```

--- a/src/Snicco/Bundle/encryption/README.md
+++ b/src/Snicco/Bundle/encryption/README.md
@@ -14,7 +14,7 @@ Make sure you have a read the [documentation of `defuse/php-encryption`](https:/
 ## Installation
 
 ```shell
-composer install snicco/encryption-bundle
+composer require snicco/encryption-bundle
 ```
 
 ## Configuration
@@ -49,12 +49,12 @@ config file.
 use Snicco\Bundle\Encryption\EncryptionBundle;
 
 return [
-    
+
     'bundles' => [
         Snicco\Component\Kernel\ValueObject\Environment::ALL => [
            EncryptionBundle::class
-        ]   
-    ]   
+        ]
+    ]
 ];
 
 ```
@@ -75,11 +75,11 @@ $plaintext = 'snicco.io';
 
 $ciphertext = $defuse->encrypt($plaintext);
 
-var_dump($plaintext === $ciphertext); // false 
+var_dump($plaintext === $ciphertext); // false
 
 $plain2 = $defuse->decrypt($ciphertext);
 
-var_dump($plaintext === $plain2); // true 
+var_dump($plaintext === $plain2); // true
 ```
 
 ## Contributing

--- a/src/Snicco/Bundle/http-routing/README.md
+++ b/src/Snicco/Bundle/http-routing/README.md
@@ -13,7 +13,7 @@ library for usage in applications based on [`snicco/kernel`](https://github.com/
 ## Installation
 
 ```shell
-composer install snicco/http-routing-bundle
+composer require snicco/http-routing-bundle
 ```
 
 ## Configuration
@@ -37,12 +37,12 @@ Add the [`HttpRoutingBundle`](src/HttpRoutingBundle.php) to your `bundles.php` c
 use Snicco\Bundle\HttpRouting\HttpRoutingBundle;
 
 return [
-    
+
     'bundles' => [
         Snicco\Component\Kernel\ValueObject\Environment::ALL => [
             HttpRoutingBundle::class
-        ]   
-    ]   
+        ]
+    ]
 ];
 ```
 
@@ -67,7 +67,7 @@ use Snicco\Component\Kernel\Kernel;
 // Create kernel
 
 /**
- * @var Kernel $kernel 
+ * @var Kernel $kernel
  */
 $kernel->boot();
 

--- a/src/Snicco/Bundle/session/README.md
+++ b/src/Snicco/Bundle/session/README.md
@@ -14,7 +14,7 @@ The [`snicco/http-routing-bundle`](https://github.com/snicco/http-routing-bundle
 ## Installation
 
 ```shell
-composer install snicco/session-bundle
+composer require snicco/session-bundle
 ```
 
 ## Configuration
@@ -34,12 +34,12 @@ config file.
 use Snicco\Bundle\Session\SessionBundle;
 
 return [
-    
+
     'bundles' => [
         Snicco\Component\Kernel\ValueObject\Environment::ALL => [
            SessionBundle::class
-        ]   
-    ]   
+        ]
+    ]
 ];
 ```
 
@@ -72,7 +72,7 @@ return [
             ShareSessionWithViews::class,
             SaveResponseAttributes::class,
 //            SessionNoCache::class, optional
-        ]   
+        ]
     ],
     MiddlewareOption::ALIASES => [
         'session-allow-write' => AllowMutableSessionForReadVerbs::class,

--- a/src/Snicco/Bundle/templating/README.md
+++ b/src/Snicco/Bundle/templating/README.md
@@ -12,7 +12,7 @@ This **WordPress** bundle integrates [`snicco/templating`](https://github.com/sn
 ## Installation
 
 ```shell
-composer install snicco/templating-bundle
+composer require snicco/templating-bundle
 ```
 
 ## Configuration
@@ -32,12 +32,12 @@ config file.
 use Snicco\Bundle\Templating\TemplatingBundle;
 
 return [
-    
+
     'bundles' => [
         Snicco\Component\Kernel\ValueObject\Environment::ALL => [
            TemplatingBundle::class
-        ]   
-    ]   
+        ]
+    ]
 ];
 ```
 
@@ -48,7 +48,7 @@ return [
 The [`TemplatingBundle`](src/TemplatingBundle.php) provides a [`TemplatingMiddleware`](src/TemplatingMiddleware.php) that
 renders `ViewResponses` by using the templating engine of the [`snicco/templating`](https://github.com/snicco/templating) library.
 
-It should replace the simpler `SimpleTemplating` middleware of the `http-routing-bundle`. 
+It should replace the simpler `SimpleTemplating` middleware of the `http-routing-bundle`.
 
 ### View context
 
@@ -59,7 +59,7 @@ When resolving the `TemplateEngine` from the booted kernel the following context
 
 ### Error handling
 
-The [`TemplatingBundle`](src/TemplatingBundle.php) will register a [`TemplatingExceptionDisplayer`](src/TemplatingExceptionDisplayer.php) if the `http-routing-bundle` is used. 
+The [`TemplatingBundle`](src/TemplatingBundle.php) will register a [`TemplatingExceptionDisplayer`](src/TemplatingExceptionDisplayer.php) if the `http-routing-bundle` is used.
 
 This exception displayer can be added in your `http_error_handling` configuration.
 

--- a/src/Snicco/Bundle/testing/README.md
+++ b/src/Snicco/Bundle/testing/README.md
@@ -12,7 +12,7 @@ The testing bundle provides a full testing framework for **WordPress** applicati
 ## Installation
 
 ```shell
-composer install snicco/testing-bundle
+composer require snicco/testing-bundle
 ```
 
 ## Usage
@@ -27,31 +27,31 @@ use Snicco\Bundle\Testing\Functional\WebTestCase;
 class SomeTest extends WebTestCase {
 
     protected function extensions() : array{
-        return []; // Return an array of class names implementing TestExtension 
+        return []; // Return an array of class names implementing TestExtension
     }
-    
+
     protected function createKernel(){
         return '/path/to/kernel-bootstrap.php' // Path to kernel bootstrap file (assuming this file returns a closure).
     }
-    
+
     public function testHomePage(){
-        
+
         /** @var Browser $browser */
         $browser = $this->getBrowser();
-              
+
         $browser->request('/');
-                
+
         $browser->lastResponse()
                 ->assertOk()
                 ->assertSeeText('Some text');
-                
+
         $browser->lastDOM()->assertSelectorExists('body > h1');
-        
+
         $browser->reload();
-        
+
         $browser->back();
-        
-    }    
+
+    }
 }
 ```
 

--- a/src/Snicco/Component/better-wp-mail/README.md
+++ b/src/Snicco/Component/better-wp-mail/README.md
@@ -61,14 +61,14 @@ This is what you probably find in most **WordPress** plugin code:
 ```php
 
 function my_plugin_send_mail(string $to, string $html_message) {
-    
+
     add_filter('phpmailer_init', 'add_plain_text');
-    
+
     /* Add ten other filters */
     wp_mail($to, $html_message);
-    
+
     remove_filter('phpmailer_init', 'add_plain_text')
-    
+
     /* Remove ten other filters */
 }
 
@@ -190,7 +190,7 @@ $email = $email->withTo('jondoe@snicco.io');
 // The email has one recipient "jondoe@snicco.io"
 ```
 
---- 
+---
 
 ### Sending an email
 
@@ -221,22 +221,22 @@ $email = new Email();
 $admin = new WP_User(1);
 
 $email = $email
-    
+
     // email address is a simple string
     ->addTo('calvin@snicco.io')
-    
+
     // with an explicit display name
     ->addCc('Marlon <marlon@snicco.io>')
-    
+
     // as an array, where the first argument is the email
-    ->addBcc(['Jon Doe', 'jon@snicco.io'])        
-    
-    // as an array with a "name" + "email" key        
+    ->addBcc(['Jon Doe', 'jon@snicco.io'])
+
+    // as an array with a "name" + "email" key
     ->addFrom(['name' => 'Jane Doe', 'email' => 'jane@snicco.io'])
 
     // with an instance of WP_USER
-    ->addFrom($admin)        
-    
+    ->addFrom($admin)
+
     // with an instance of MailBox
     ->addReplyTo(Mailbox::create('no-reply@snicco.io'));
 ```
@@ -291,18 +291,18 @@ use Snicco\Component\BetterWPMail\ValueObject\Email;
 $email = (new Email())
 
     ->withHtmlTemplate('path/to/email-templates/welcome.php')
-    
+
     ->withContext(['site_name' => 'snicco.io']);
 
 // Important: don't use withContext here or site_name is gone.
 $email1 = $email->addContext('first_name', 'Calvin')
                 ->addTo('calvin@snicco.io');
-                
+
 $mailer->send($email1);
 
 $email2 = $email->addContext('first_name', 'Marlon');
                 ->addTo('marlon@snicco.io');
-                
+
 $mailer->send($email2);
 ```
 
@@ -320,7 +320,7 @@ This will result in the following two emails being sent:
 <p>Thanks for signing up to snicco.io</p>
 ```
 
---- 
+---
 
 ### Adding attachments
 
@@ -330,39 +330,39 @@ Attachments can be added to an instance of [`Email`](src/ValueObject/Email.php) 
 
   ```php
   use Snicco\Component\BetterWPMail\ValueObject\Email;
-  
+
   $email = (new Email())->addTo('calvin@snicco.io');
-  
+
   $email = $email
-  
+
       ->addAttachment('/path/to/documents/terms-of-use.pdf')
-      
+
       // optionally with a custom display name
       ->addAttachment('/path/to/documents/privacy.pdf', 'Privacy Policy')
-      
+
       // optionally with an explicit content-type,
       ->addAttachment('/path/to/documents/contract.doc', 'Contract', 'application/msword');
-  
+
   ```
 
 2. Attaching a binary string or a stream that you already have in memory (a generated PDF for example)
 
   ```php
   use Snicco\Component\BetterWPMail\ValueObject\Email;
-  
+
   $pdf = /* generate pdf */
-  
+
   $email = (new Email())->addTo('calvin@snicco.io');
-  
+
   $email = $email
-  
+
       ->addBinaryAttachment($pdf, 'Your PDF', 'application/pdf')
-  
+
   ```
 
 **BetterWPMail** depends on it's [`Transport` interface](src/Transport/Transport.php) to perform the actual sending
 of emails. For that reason, no mime-type detection is performed if you don't pass an explicit content-type for an
-attachment. This is delegated to the concrete transport implementation. 
+attachment. This is delegated to the concrete transport implementation.
 
 The [`WPMailTransport`](src/Transport/WPMailTransport.php) will delegate this task to `wp_mail`/`PHPMailer`.
 The behaviour of `PHPMailer` is the following:
@@ -391,19 +391,19 @@ In your email content you can then reference the embedded image with the syntax:
 
 ```php
   use Snicco\Component\BetterWPMail\ValueObject\Email;
-  
+
   $email = (new Email())
     ->addTo('calvin@snicco.io')
     ->addContext('first_name', 'Calvin');
-  
+
   $email1 = $email
       ->addEmbed('/path/to/images/logo.png', 'logo', 'image/png')
       ->withHtmlTemplate('path/to/email-templates/welcome-with-image.php');
-  
+
   // or with inline html
   $email2 = $email
       ->addEmbed('/path/to/images/logo.png', 'logo', 'image/png')
-      ->withHtmlBody('<img src="cid:logo">');  
+      ->withHtmlBody('<img src="cid:logo">');
 
   ```
 
@@ -413,7 +413,7 @@ In your email content you can then reference the embedded image with the syntax:
 
 ```php
   use Snicco\Component\BetterWPMail\ValueObject\Email;
-  
+
   $email = (new Email())
     ->addTo('calvin@snicco.io')
     // custom headers are string, string key value pairs.
@@ -446,8 +446,8 @@ $reply_to_email = 'myplugin-reply-to@site.com';
 
 $mail_defaults = new MailDefaults(
     $from_name,
-     $from_email, 
-     $reply_to_name, 
+     $from_email,
+     $reply_to_name,
      $reply_to_email
 );
 
@@ -471,24 +471,24 @@ use Snicco\Component\BetterWPMail\ValueObject\Email;
 use Snicco\Component\BetterWPMail\ValueObject\Mailbox;
 
 class WelcomeEmail extends Email {
-        
+
     // You can configure the protected
-    // priorities of the Email class    
+    // priorities of the Email class
     protected ?int $priority = 5;
-    
+
     protected string $text = 'We would like to welcome you to snicco.io';
-    
+
     protected ?string $html_template = '/path/to/templates/welcome.php';
-    
+
     public function __construct(WP_User $user) {
-    
+
         // configure dynamic properties in the constructor.
         $this->subject = sprintf('Welcome to snicco.io %s', $user->display_name);
-        
+
         $this->to[] = Mailbox::create($user);
-        
+
         $this->context['first_name'] = $user->first_name;
-        
+
     }
 
 }
@@ -576,7 +576,7 @@ First we need a way to convert markdown to HTML.
 
 We will use [`erusev/parsedown`](https://github.com/erusev/parsedown) for this task.
 
-```shell 
+```shell
 composer require erusev/parsedown
 ```
 
@@ -586,29 +586,29 @@ Now let's create a custom `MarkdownMailRenderer`:
 use Snicco\Component\BetterWPMail\Renderer\MailRenderer;
 
 class MarkdownEmailRenderer implements MailRenderer {
-    
+
     // This renderer should only render .md files that exist.
     public function supports(string $template_name,?string $extension = null) : bool{
-        
+
         return 'md' === $extension && is_file($template_name);
-            
+
     }
-    
+
     public function render(string $template_name,array $context = []) : string{
-        
+
         // First, we get the string contents of the template.
         $contents = file_get_contents($template_name);
-        
-        // To allow basic templating, replace placeholders inside {{ }} 
+
+        // To allow basic templating, replace placeholders inside {{ }}
         foreach ($context as $name => $value ) {
             $contents = str_replace('{{'.$name'.}}', $value);
         }
-        
+
         // Convert the markdown to HTML and return it.
         return (new Parsedown())->text($contents);
-                        
+
     }
-    
+
 }
 
 ```
@@ -694,7 +694,7 @@ testing.
 First, install the package as a composer `dev-dependency`:
 
 ```shell
-composer install --dev snicco/better-wp-mail-testing
+composer require --dev snicco/better-wp-mail-testing
 ```
 
 How you wire the `FakeTransport` into your [`Mailer`](src/Mailer.php) instance during testing greatly depends on how


### PR DESCRIPTION
A few of the bundle READMEs contain `composer install snicco/package-name` when instead it should read `composer require snicco/package-name`. That is being fixed in this PR.