### PR TITLE
fix(*): fix typos

### DIFF
--- a/.github/ISSUE_TEMPLATE/doc-error-request.yaml
+++ b/.github/ISSUE_TEMPLATE/doc-error-request.yaml
@@ -18,7 +18,7 @@ body:
   - type: dropdown
     id: affected-packages
     attributes:
-      label: "Which @snicco/* package(s) have missing/wrong/unclear documenation?"
+      label: "Which @snicco/* package(s) have missing/wrong/unclear documentation?"
       options:
         - monorepo
         - other/dont-know

--- a/src/Snicco/Bridge/blade/README.md
+++ b/src/Snicco/Bridge/blade/README.md
@@ -49,7 +49,7 @@ $blade = new BladeStandalone(
 );
 
 
-$blade->boostrap();
+$blade->bootstrap();
 
 /**
 * @var BladeViewFactory

--- a/src/Snicco/Bridge/blade/src/BladeStandalone.php
+++ b/src/Snicco/Bridge/blade/src/BladeStandalone.php
@@ -80,7 +80,7 @@ final class BladeStandalone
         return $this->illuminate_container->get(BladeViewFactory::class);
     }
 
-    public function boostrap(): void
+    public function bootstrap(): void
     {
         $this->bindDependencies();
         $this->bootIlluminateViewServiceProvider();

--- a/src/Snicco/Bridge/blade/src/BladeViewFactory.php
+++ b/src/Snicco/Bridge/blade/src/BladeViewFactory.php
@@ -42,7 +42,7 @@ final class BladeViewFactory implements ViewFactory
     }
 
     /**
-     * @interal
+     * @internal
      *
      * @throws ViewNotFound
      *
@@ -63,7 +63,7 @@ final class BladeViewFactory implements ViewFactory
     }
 
     /**
-     * @interal
+     * @internal
      *
      * @throws ViewCantBeRendered
      *

--- a/src/Snicco/Bridge/blade/tests/BladeStandaloneTest.php
+++ b/src/Snicco/Bridge/blade/tests/BladeStandaloneTest.php
@@ -55,7 +55,7 @@ final class BladeStandaloneTest extends BladeTestCase
 
         $this->composers = new ViewContextResolver(new GlobalViewContext(), null);
         $blade = new BladeStandalone($this->blade_cache, [$this->blade_views], $this->composers);
-        $blade->boostrap();
+        $blade->bootstrap();
 
         $this->assertSame('bar', $config['foo']);
     }

--- a/src/Snicco/Bridge/blade/tests/BladeTestCase.php
+++ b/src/Snicco/Bridge/blade/tests/BladeTestCase.php
@@ -54,7 +54,7 @@ abstract class BladeTestCase extends TestCase
 
         $this->composers = new ViewContextResolver($global_view_context = new GlobalViewContext(), null);
         $blade = new BladeStandalone($this->blade_cache, [$this->blade_views], $this->composers);
-        $blade->boostrap();
+        $blade->bootstrap();
         $this->blade = $blade;
 
         $this->view_engine = new TemplateEngine($blade->getBladeViewFactory());

--- a/src/Snicco/Bridge/blade/tests/UnsupportedDirectivesTest.php
+++ b/src/Snicco/Bridge/blade/tests/UnsupportedDirectivesTest.php
@@ -34,7 +34,7 @@ final class UnsupportedDirectivesTest extends BladeTestCase
     /**
      * @test
      */
-    public function csrf_directive_throws_expection(): void
+    public function csrf_directive_throws_exception(): void
     {
         $view = $this->view('csrf');
 

--- a/src/Snicco/Bundle/blade/src/BladeBundle.php
+++ b/src/Snicco/Bundle/blade/src/BladeBundle.php
@@ -60,7 +60,7 @@ final class BladeBundle implements Bundle
                 $composers
             );
 
-            $blade->boostrap();
+            $blade->bootstrap();
             $this->bindWordPressBladeDirectives();
 
             return $blade->getBladeViewFactory();

--- a/src/Snicco/Bundle/http-routing/src/HttpKernelRunner.php
+++ b/src/Snicco/Bundle/http-routing/src/HttpKernelRunner.php
@@ -37,7 +37,7 @@ final class HttpKernelRunner
     private ApiRequestDetector $api_request_detector;
 
     /**
-     * @interal
+     * @internal
      *
      * @psalm-internal Snicco\Bundle\HttpRouting
      */

--- a/src/Snicco/Bundle/http-routing/src/MiddlewareCache.php
+++ b/src/Snicco/Bundle/http-routing/src/MiddlewareCache.php
@@ -18,7 +18,7 @@ use function var_export;
 /**
  * @psalm-internal Snicco\Bundle\HttpRouting
  *
- * @interal
+ * @internal
  */
 final class MiddlewareCache
 {

--- a/src/Snicco/Bundle/http-routing/src/ResponsePostProcessor.php
+++ b/src/Snicco/Bundle/http-routing/src/ResponsePostProcessor.php
@@ -11,7 +11,7 @@ use Snicco\Component\Kernel\ValueObject\Environment;
  * @psalm-external-mutation-free
  * @psalm-internal Snicco\Bundle\HttpRouting
  *
- * @interal
+ * @internal
  */
 final class ResponsePostProcessor implements Unremovable
 {

--- a/src/Snicco/Bundle/templating/README.md
+++ b/src/Snicco/Bundle/templating/README.md
@@ -55,7 +55,7 @@ It should replace the simpler `SimpleTemplating` middleware of the `http-routing
 When resolving the `TemplateEngine` from the booted kernel the following context will be available in all views:
 
 - `url` => an instance of `UrlGenerator`
-- `view` => the `TemplatEngine` instance itself
+- `view` => the `TemplateEngine` instance itself
 
 ### Error handling
 

--- a/src/Snicco/Component/better-wp-api/README.md
+++ b/src/Snicco/Component/better-wp-api/README.md
@@ -38,7 +38,7 @@ Directly interacting with core functions was problematic for us because:
 If you can't relate to these issues, you probably don't need this library.
 
 **Edit:** The scoping problem was solved, by us creating
-a [command-line-programm](https://github.com/snicco/php-scoper-excludes) that can be used to generate
+a [command-line-program](https://github.com/snicco/php-scoper-excludes) that can be used to generate
 a [list of all functions and classes](https://github.com/snicco/php-scoper-wordpress-excludes/blob/master/generated/exclude-wordpress-functions.json)
 in the entire **WordPress** core codebase. For now, the best example on how to use it
 is [the `scoper.inc.php` configuration](https://github.com/GoogleForCreators/web-stories-wp/blob/main/scoper.inc.php#L13)

--- a/src/Snicco/Component/better-wp-cache/src/WPCacheItem.php
+++ b/src/Snicco/Component/better-wp-cache/src/WPCacheItem.php
@@ -17,7 +17,7 @@ use function sprintf;
 /**
  * @psalm-internal Snicco\Component\BetterWPCache
  *
- * @interal
+ * @internal
  */
 final class WPCacheItem implements CacheItemInterface
 {

--- a/src/Snicco/Component/better-wp-cache/tests/wordpress/WPObjectCachePsr16IntegrationTest.php
+++ b/src/Snicco/Component/better-wp-cache/tests/wordpress/WPObjectCachePsr16IntegrationTest.php
@@ -432,7 +432,7 @@ final class WPObjectCachePsr16IntegrationTest extends WPTestCase
             } elseif ('key1' === $key) {
                 $this->assertNull($r);
             } else {
-                $this->assertFalse(true, 'This should not happend');
+                $this->assertFalse(true, 'This should not happen');
             }
         }
 
@@ -582,7 +582,7 @@ final class WPObjectCachePsr16IntegrationTest extends WPTestCase
 
         try {
             $this->cache->set($key, 'foobar');
-            $this->fail(sprintf('No expection was thrown for key [%s]', $key));
+            $this->fail(sprintf('No exception was thrown for key [%s]', $key));
         } catch (InvalidArgumentException $e) {
             $this->assertTrue(true);
         }

--- a/src/Snicco/Component/better-wp-cli/src/Check.php
+++ b/src/Snicco/Component/better-wp-cli/src/Check.php
@@ -10,7 +10,7 @@ use function get_resource_type;
 use function is_resource;
 
 /**
- * @interal
+ * @internal
  *
  * @psalm-internal Snicco\Component\BetterWPCLI
  */

--- a/src/Snicco/Component/better-wp-cli/src/Output/StreamOutput.php
+++ b/src/Snicco/Component/better-wp-cli/src/Output/StreamOutput.php
@@ -44,7 +44,7 @@ final class StreamOutput extends OutputWithVerbosity
     }
 
     /**
-     * @interal
+     * @internal
      *
      * @psalm-internal Snicco\Component\BetterWPCLI\Output
      */

--- a/src/Snicco/Component/better-wp-cli/src/Synopsis/InputArgument.php
+++ b/src/Snicco/Component/better-wp-cli/src/Synopsis/InputArgument.php
@@ -113,7 +113,7 @@ final class InputArgument implements InputDefinition
     }
 
     /**
-     * @interal
+     * @internal
      *
      * @return array{type: string, name: string, description: string, optional: bool, repeating: bool, default?: string, options?: string[]}
      *
@@ -146,7 +146,7 @@ final class InputArgument implements InputDefinition
     }
 
     /**
-     * @interal
+     * @internal
      *
      * @psalm-internal Snicco\Component\BetterWPCLI
      */
@@ -156,7 +156,7 @@ final class InputArgument implements InputDefinition
     }
 
     /**
-     * @interal
+     * @internal
      *
      * @psalm-internal Snicco\Component\BetterWPCLI
      */

--- a/src/Snicco/Component/better-wp-cli/src/Synopsis/InputDefinition.php
+++ b/src/Snicco/Component/better-wp-cli/src/Synopsis/InputDefinition.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Snicco\Component\BetterWPCLI\Synopsis;
 
 /**
- * @interal
+ * @internal
  *
  * @psalm-internal Snicco\Component\BetterWPCLI
  */

--- a/src/Snicco/Component/better-wp-cli/src/Synopsis/InputFlag.php
+++ b/src/Snicco/Component/better-wp-cli/src/Synopsis/InputFlag.php
@@ -27,7 +27,7 @@ final class InputFlag implements InputDefinition
     }
 
     /**
-     * @interal
+     * @internal
      *
      * @return array{type: string, name: string, description: string, optional: true}
      *

--- a/src/Snicco/Component/better-wp-cli/src/Synopsis/InputOption.php
+++ b/src/Snicco/Component/better-wp-cli/src/Synopsis/InputOption.php
@@ -26,7 +26,7 @@ final class InputOption implements InputDefinition
     /**
      * @var int
      */
-    public const COMMA_SEPERATED = 4;
+    public const COMMA_SEPARATED = 4;
 
     private string $name;
 
@@ -34,7 +34,7 @@ final class InputOption implements InputDefinition
 
     private bool $optional;
 
-    private bool $comma_seperated;
+    private bool $comma_separated;
 
     private ?string $default;
 
@@ -77,7 +77,7 @@ final class InputOption implements InputDefinition
             throw new LogicException('Input option must be either required or optional.');
         }
 
-        $this->comma_seperated = self::COMMA_SEPERATED === (self::COMMA_SEPERATED & $flags);
+        $this->comma_separated = self::COMMA_SEPARATED === (self::COMMA_SEPARATED & $flags);
         $this->optional = $optional;
 
         if (null !== $allowed_values) {
@@ -112,7 +112,7 @@ final class InputOption implements InputDefinition
     }
 
     /**
-     * @interal
+     * @internal
      *
      * @return array{type: string, name: string, description: string, optional: bool, repeating?: true, default?:string, options?: string[]}
      *
@@ -127,8 +127,8 @@ final class InputOption implements InputDefinition
             'optional' => $this->optional,
         ];
 
-        if ($this->comma_seperated) {
-            $data['description'] .= ' (supports multiple comma-seperated values)';
+        if ($this->comma_separated) {
+            $data['description'] .= ' (supports multiple comma-separated values)';
             $data['repeating'] = true;
         }
 

--- a/src/Snicco/Component/better-wp-cli/src/Synopsis/Synopsis.php
+++ b/src/Snicco/Component/better-wp-cli/src/Synopsis/Synopsis.php
@@ -52,7 +52,7 @@ final class Synopsis
     }
 
     /**
-     * @interal
+     * @internal
      *
      * @return array<string,InputArgument>
      *
@@ -74,7 +74,7 @@ final class Synopsis
     }
 
     /**
-     * @interal
+     * @internal
      *
      * @psalm-internal Snicco\Component\BetterWPCLI
      * @psalm-mutation-free

--- a/src/Snicco/Component/better-wp-cli/tests/unit/Output/StreamOutputTest.php
+++ b/src/Snicco/Component/better-wp-cli/tests/unit/Output/StreamOutputTest.php
@@ -128,7 +128,7 @@ final class StreamOutputTest extends TestCase
     /**
      * @test
      */
-    public function colors_with_hyper_term_programm(): void
+    public function colors_with_hyper_term_program(): void
     {
         try {
             putenv('TERM_PROGRAM=Hyper');

--- a/src/Snicco/Component/better-wp-cli/tests/unit/Synopsis/InputOptionTest.php
+++ b/src/Snicco/Component/better-wp-cli/tests/unit/Synopsis/InputOptionTest.php
@@ -69,20 +69,20 @@ final class InputOptionTest extends TestCase
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Input option must be either required or optional');
 
-        new InputOption('name', 'description', InputOption::COMMA_SEPERATED, );
+        new InputOption('name', 'description', InputOption::COMMA_SEPARATED, );
     }
 
     /**
      * @test
      */
-    public function is_optional_and_required_and_comma_seperated_throws_exception(): void
+    public function is_optional_and_required_and_comma_separated_throws_exception(): void
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Input option can not be required and optional.');
         new InputOption(
             'name',
             'description',
-            InputOption::OPTIONAL | InputOption::REQUIRED | InputOption::COMMA_SEPERATED,
+            InputOption::OPTIONAL | InputOption::REQUIRED | InputOption::COMMA_SEPARATED,
         );
     }
 
@@ -109,13 +109,13 @@ final class InputOptionTest extends TestCase
     /**
      * @test
      */
-    public function with_comma_seperated_adds_description(): void
+    public function with_comma_separated_adds_description(): void
     {
-        $option = new InputOption('name', 'description', InputOption::REQUIRED | InputOption::COMMA_SEPERATED);
+        $option = new InputOption('name', 'description', InputOption::REQUIRED | InputOption::COMMA_SEPARATED);
         $this->assertSame([
             'type' => 'assoc',
             'name' => 'name',
-            'description' => 'description (supports multiple comma-seperated values)',
+            'description' => 'description (supports multiple comma-separated values)',
             'optional' => false,
             'repeating' => true,
         ], $option->toArray());
@@ -170,13 +170,13 @@ final class InputOptionTest extends TestCase
     /**
      * @test
      */
-    public function is_comma_seperated_and_required(): void
+    public function is_comma_separated_and_required(): void
     {
-        $option = new InputOption('name', 'description', InputOption::COMMA_SEPERATED | InputOption::REQUIRED, );
+        $option = new InputOption('name', 'description', InputOption::COMMA_SEPARATED | InputOption::REQUIRED, );
         $this->assertSame([
             'type' => 'assoc',
             'name' => 'name',
-            'description' => 'description (supports multiple comma-seperated values)',
+            'description' => 'description (supports multiple comma-separated values)',
             'optional' => false,
             'repeating' => true,
         ], $option->toArray());
@@ -187,11 +187,11 @@ final class InputOptionTest extends TestCase
      */
     public function is_optional_and_comma_separated(): void
     {
-        $option = new InputOption('name', 'description', InputOption::OPTIONAL | InputOption::COMMA_SEPERATED, );
+        $option = new InputOption('name', 'description', InputOption::OPTIONAL | InputOption::COMMA_SEPARATED, );
         $this->assertSame([
             'type' => 'assoc',
             'name' => 'name',
-            'description' => 'description (supports multiple comma-seperated values)',
+            'description' => 'description (supports multiple comma-separated values)',
             'optional' => true,
             'repeating' => true,
         ], $option->toArray());

--- a/src/Snicco/Component/better-wp-hooks/README.md
+++ b/src/Snicco/Component/better-wp-hooks/README.md
@@ -389,8 +389,8 @@ class DeterminingOrderPrice implements MappedFilter {
     public int $initial_order_total;
     
     public function __construct(int $initial_order_total) {
-        $this->new_total = $intial_order_total;
-        $this->initial_order_total = $intial_order_total;
+        $this->new_total = $initial_order_total;
+        $this->initial_order_total = $initial_order_total;
     }
     
     public function filterableAttribute(){

--- a/src/Snicco/Component/better-wp-hooks/src/WPHookAPI.php
+++ b/src/Snicco/Component/better-wp-hooks/src/WPHookAPI.php
@@ -21,7 +21,7 @@ final class WPHookAPI extends BetterWPAPI
     /**
      * @psalm-internal Snicco\Component\BetterWPHooks
      *
-     * @interal
+     * @internal
      */
     public function currentFilter(): ?string
     {
@@ -37,7 +37,7 @@ final class WPHookAPI extends BetterWPAPI
     /**
      * @psalm-internal Snicco\Component\BetterWPHooks
      *
-     * @interal
+     * @internal
      */
     public function getHook(string $hook_name): ?WP_Hook
     {

--- a/src/Snicco/Component/better-wp-mail/README.md
+++ b/src/Snicco/Component/better-wp-mail/README.md
@@ -700,7 +700,7 @@ composer install --dev snicco/better-wp-mail-testing
 How you wire the `FakeTransport` into your [`Mailer`](src/Mailer.php) instance during testing greatly depends on how
 your overall codebase is set up. You probably want to do this inside your dependency-injection container.
 
-The `FakeTranport` has the following **phpunit** assertion methods:
+The `FakeTransport` has the following **phpunit** assertion methods:
 
 ```php
 use Snicco\Component\BetterWPMail\Mailer;

--- a/src/Snicco/Component/better-wp-mail/src/WPMailAPI.php
+++ b/src/Snicco/Component/better-wp-mail/src/WPMailAPI.php
@@ -13,7 +13,7 @@ use function wp_mail;
 /**
  * @psalm-internal Snicco\Component\BetterWPMail
  *
- * @interal
+ * @internal
  */
 final class WPMailAPI extends BetterWPAPI
 {

--- a/src/Snicco/Component/better-wp-mail/tests/wordpress/MailerTest.php
+++ b/src/Snicco/Component/better-wp-mail/tests/wordpress/MailerTest.php
@@ -746,7 +746,7 @@ final class MailerTest extends WPTestCase
     /**
      * @test
      */
-    public function attachments_can_be_embeded_from_memory(): void
+    public function attachments_can_be_embedded_from_memory(): void
     {
         $mailer = new Mailer();
 

--- a/src/Snicco/Component/better-wpdb/src/Exception/QueryException.php
+++ b/src/Snicco/Component/better-wpdb/src/Exception/QueryException.php
@@ -41,7 +41,7 @@ class QueryException extends RuntimeException
     /**
      * @param array<scalar|null> $bindings
      *
-     * @interal
+     * @internal
      */
     public static function fromMysqliE(string $sql, array $bindings, mysqli_sql_exception $e): self
     {

--- a/src/Snicco/Component/better-wpdb/src/KeysetPagination/Lock.php
+++ b/src/Snicco/Component/better-wpdb/src/KeysetPagination/Lock.php
@@ -12,7 +12,7 @@ final class Lock
     /**
      * @var "lock in share mode"|"for update"
      *
-     * @interal
+     * @internal
      *
      * @psalm-internal Snicco\Component\BetterWPDB
      */

--- a/src/Snicco/Component/better-wpdb/src/KeysetPagination/Query.php
+++ b/src/Snicco/Component/better-wpdb/src/KeysetPagination/Query.php
@@ -103,7 +103,7 @@ final class Query
     }
 
     /**
-     * @interal
+     * @internal
      *
      * @param list<array<string,?scalar>> $batch
      */
@@ -136,7 +136,7 @@ final class Query
     }
 
     /**
-     * @interal
+     * @internal
      *
      * @return array{0: non-empty-string, 1: array<scalar|null>}
      */

--- a/src/Snicco/Component/better-wpdb/tests/wordpress/BetterWPDB_transactions_Test.php
+++ b/src/Snicco/Component/better-wpdb/tests/wordpress/BetterWPDB_transactions_Test.php
@@ -69,7 +69,7 @@ final class BetterWPDB_transactions_Test extends BetterWPDBTestCase
     /**
      * @test
      */
-    public function test_nested_transactions_throw_expection(): void
+    public function test_nested_transactions_throw_exception(): void
     {
         try {
             $this->better_wpdb->transactional(function (BetterWPDB $db): void {

--- a/src/Snicco/Component/eloquent/src/Illuminate/WPConnectionResolver.php
+++ b/src/Snicco/Component/eloquent/src/Illuminate/WPConnectionResolver.php
@@ -19,7 +19,7 @@ use Snicco\Component\Eloquent\Mysqli\MysqliFactory;
  *
  * @psalm-internal Snicco\Component\Eloquent
  *
- * @interal
+ * @internal
  */
 final class WPConnectionResolver implements IlluminateConnectionResolver
 {

--- a/src/Snicco/Component/eloquent/src/Mysqli/MysqliDriver.php
+++ b/src/Snicco/Component/eloquent/src/Mysqli/MysqliDriver.php
@@ -21,7 +21,7 @@ use function sprintf;
  *
  * @psalm-internal Snicco\Component\Eloquent
  *
- * @interal
+ * @internal
  */
 final class MysqliDriver implements MysqliDriverInterface
 {

--- a/src/Snicco/Component/eloquent/src/Mysqli/MysqliDriverInterface.php
+++ b/src/Snicco/Component/eloquent/src/Mysqli/MysqliDriverInterface.php
@@ -10,7 +10,7 @@ use RuntimeException;
 /**
  * @psalm-internal Snicco\Component\Eloquent
  *
- * @interal
+ * @internal
  */
 interface MysqliDriverInterface extends PDOAdapter
 {

--- a/src/Snicco/Component/eloquent/src/Mysqli/MysqliFactory.php
+++ b/src/Snicco/Component/eloquent/src/Mysqli/MysqliFactory.php
@@ -13,7 +13,7 @@ use Snicco\Component\Eloquent\WPDatabaseSettingsAPI;
 /**
  * @psalm-internal Snicco\Component\Eloquent
  *
- * @interal
+ * @internal
  */
 final class MysqliFactory
 {

--- a/src/Snicco/Component/eloquent/src/Mysqli/MysqliReconnect.php
+++ b/src/Snicco/Component/eloquent/src/Mysqli/MysqliReconnect.php
@@ -11,7 +11,7 @@ use RuntimeException;
 /**
  * @psalm-internal Snicco\Component\Eloquent
  *
- * @interal
+ * @internal
  */
 final class MysqliReconnect
 {

--- a/src/Snicco/Component/eloquent/src/Mysqli/PDOAdapter.php
+++ b/src/Snicco/Component/eloquent/src/Mysqli/PDOAdapter.php
@@ -16,7 +16,7 @@ namespace Snicco\Component\Eloquent\Mysqli;
  *
  * @psalm-internal Snicco\Component\Eloquent
  *
- * @interal
+ * @internal
  */
 interface PDOAdapter
 {

--- a/src/Snicco/Component/eloquent/src/WPDatabaseSettingsAPI.php
+++ b/src/Snicco/Component/eloquent/src/WPDatabaseSettingsAPI.php
@@ -19,7 +19,7 @@ use const DB_USER;
 /**
  * @psalm-internal Snicco\Component\Eloquent
  *
- * @interal
+ * @internal
  */
 final class WPDatabaseSettingsAPI extends BetterWPAPI
 {

--- a/src/Snicco/Component/event-dispatcher/src/ClosureTypeHint.php
+++ b/src/Snicco/Component/event-dispatcher/src/ClosureTypeHint.php
@@ -12,7 +12,7 @@ use ReflectionParameter;
 use Snicco\Component\EventDispatcher\Exception\InvalidListener;
 
 /**
- * @interal
+ * @internal
  *
  * @psalm-internal Snicco\Component\EventDispatcher
  */

--- a/src/Snicco/Component/http-routing/README.md
+++ b/src/Snicco/Component/http-routing/README.md
@@ -496,7 +496,7 @@ template engine inside a custom middleware to achieve this.
 #### Admin routes
 
 Routes defined in a `admin.php` file are special in a sense that they can be used to create routes to the admin area of
-a CMS like **WordPress** where you usually don't have control ofter the "routing".
+a CMS like **WordPress** where you usually don't have control over the "routing".
 
 You can even create admin menu items directly from your route definitions.
 
@@ -694,7 +694,7 @@ The central piece is the [`MiddlewarePipeline`](src/Middleware/MiddlewarePipelin
 The middleware pipeline needs a [**PSR-11** container](https://www.php-fig.org/psr/psr-11/) to lazily resolve your
 controllers and middleware.
 
-Furthermore, an instance of [`HTTPErrorHanlder`](https://github.com/snicco/psr7-error-handler) is needed to handle
+Furthermore, an instance of [`HTTPErrorHandler`](https://github.com/snicco/psr7-error-handler) is needed to handle
 exceptions for each middleware.
 
 ```php

--- a/src/Snicco/Component/http-routing/src/Controller/ControllerAction.php
+++ b/src/Snicco/Component/http-routing/src/Controller/ControllerAction.php
@@ -20,7 +20,7 @@ use function call_user_func_array;
 /**
  * @psalm-internal Snicco\Component\HttpRouting
  *
- * @interal
+ * @internal
  */
 final class ControllerAction
 {

--- a/src/Snicco/Component/http-routing/src/Controller/ControllerMiddleware.php
+++ b/src/Snicco/Component/http-routing/src/Controller/ControllerMiddleware.php
@@ -47,7 +47,7 @@ final class ControllerMiddleware
     }
 
     /**
-     * @interal
+     * @internal
      *
      * @psalm-mutation-free
      */
@@ -73,7 +73,7 @@ final class ControllerMiddleware
     }
 
     /**
-     * @interal
+     * @internal
      *
      * @return class-string<MiddlewareInterface>[]
      */

--- a/src/Snicco/Component/http-routing/src/Controller/DelegateResponseController.php
+++ b/src/Snicco/Component/http-routing/src/Controller/DelegateResponseController.php
@@ -9,7 +9,7 @@ use Snicco\Component\HttpRouting\Http\Response\DelegatedResponse;
 /**
  * @psalm-internal Snicco\Component\HttpRouting
  *
- * @interal
+ * @internal
  */
 final class DelegateResponseController extends Controller
 {

--- a/src/Snicco/Component/http-routing/src/Controller/RedirectController.php
+++ b/src/Snicco/Component/http-routing/src/Controller/RedirectController.php
@@ -13,7 +13,7 @@ use function array_slice;
 /**
  * @psalm-internal Snicco\Component\HttpRouting
  *
- * @interal
+ * @internal
  */
 final class RedirectController extends Controller
 {

--- a/src/Snicco/Component/http-routing/src/Controller/ViewController.php
+++ b/src/Snicco/Component/http-routing/src/Controller/ViewController.php
@@ -13,7 +13,7 @@ use function array_slice;
 /**
  * @psalm-internal Snicco\Component\HttpRouting
  *
- * @interal
+ * @internal
  */
 final class ViewController extends Controller
 {

--- a/src/Snicco/Component/http-routing/src/Http/Cookie.php
+++ b/src/Snicco/Component/http-routing/src/Http/Cookie.php
@@ -20,7 +20,7 @@ use function ucwords;
 final class Cookie
 {
     /**
-     * @interal
+     * @internal
      *
      * @var array{
      *     domain: null|string,
@@ -35,12 +35,12 @@ final class Cookie
     public array $properties;
 
     /**
-     * @interal
+     * @internal
      */
     public string $name;
 
     /**
-     * @interal
+     * @internal
      */
     public string $value;
 

--- a/src/Snicco/Component/http-routing/src/Middleware/Middleware.php
+++ b/src/Snicco/Component/http-routing/src/Middleware/Middleware.php
@@ -27,7 +27,7 @@ abstract class Middleware implements MiddlewareInterface
     private ?Request $current_request = null;
 
     /**
-     * @interal
+     * @internal
      *
      * @psalm-internal Snicco\Component\HttpRouting
      */
@@ -55,7 +55,7 @@ abstract class Middleware implements MiddlewareInterface
      * This method can be used to add the container of the current middleware to
      * a (private) middleware that is instantiated from within the current one.
      *
-     * @interal
+     * @internal
      *
      * @experimental
      *

--- a/src/Snicco/Component/http-routing/src/Middleware/MiddlewareBlueprint.php
+++ b/src/Snicco/Component/http-routing/src/Middleware/MiddlewareBlueprint.php
@@ -11,7 +11,7 @@ use Webmozart\Assert\Assert;
  * @psalm-immutable
  * @psalm-internal Snicco\Component\HttpRouting
  *
- * @interal
+ * @internal
  */
 final class MiddlewareBlueprint
 {

--- a/src/Snicco/Component/http-routing/src/Middleware/MiddlewareFactory.php
+++ b/src/Snicco/Component/http-routing/src/Middleware/MiddlewareFactory.php
@@ -19,7 +19,7 @@ use function sprintf;
 /**
  * @psalm-internal Snicco\Component\HttpRouting
  *
- * @interal
+ * @internal
  */
 final class MiddlewareFactory
 {

--- a/src/Snicco/Component/http-routing/src/Reflector.php
+++ b/src/Snicco/Component/http-routing/src/Reflector.php
@@ -20,7 +20,7 @@ use function is_string;
 use function sprintf;
 
 /**
- * @interal
+ * @internal
  * @psalm-internal Snicco\Component\HttpRouting
  */
 final class Reflector

--- a/src/Snicco/Component/http-routing/src/Routing/Admin/AdminMenuItem.php
+++ b/src/Snicco/Component/http-routing/src/Routing/Admin/AdminMenuItem.php
@@ -94,7 +94,7 @@ final class AdminMenuItem
     }
 
     /**
-     * @interal
+     * @internal
      *
      * @param array{
      *     menu_title?: string,

--- a/src/Snicco/Component/http-routing/src/Routing/Condition/ConditionBlueprint.php
+++ b/src/Snicco/Component/http-routing/src/Routing/Condition/ConditionBlueprint.php
@@ -13,7 +13,7 @@ use function sprintf;
 /**
  * @psalm-immutable
  *
- * @interal
+ * @internal
  * @psalm-internal Snicco\Component\HttpRouting
  */
 final class ConditionBlueprint

--- a/src/Snicco/Component/http-routing/src/Routing/Condition/IsAdminDashboardRequest.php
+++ b/src/Snicco/Component/http-routing/src/Routing/Condition/IsAdminDashboardRequest.php
@@ -7,7 +7,7 @@ namespace Snicco\Component\HttpRouting\Routing\Condition;
 use Snicco\Component\HttpRouting\Http\Psr7\Request;
 
 /**
- * @interal
+ * @internal
  * @psalm-internal Snicco\Component\HttpRouting
  */
 final class IsAdminDashboardRequest extends RouteCondition

--- a/src/Snicco/Component/http-routing/src/Routing/Condition/NegatedRouteCondition.php
+++ b/src/Snicco/Component/http-routing/src/Routing/Condition/NegatedRouteCondition.php
@@ -7,7 +7,7 @@ namespace Snicco\Component\HttpRouting\Routing\Condition;
 use Snicco\Component\HttpRouting\Http\Psr7\Request;
 
 /**
- * @interal
+ * @internal
  * @psalm-internal Snicco\Component\HttpRouting
  */
 final class NegatedRouteCondition extends RouteCondition

--- a/src/Snicco/Component/http-routing/src/Routing/Route/Route.php
+++ b/src/Snicco/Component/http-routing/src/Routing/Route/Route.php
@@ -28,21 +28,21 @@ use function sprintf;
 final class Route
 {
     /**
-     * @interal
+     * @internal
      *
      * @var string[]|class-string<DelegateResponseController>[]
      */
     public const DELEGATE = [DelegateResponseController::class, '__invoke'];
 
     /**
-     * @interal
+     * @internal
      *
      * @var string
      */
     public const FALLBACK_NAME = 'snicco_fallback_route';
 
     /**
-     * @interal
+     * @internal
      *
      * @var string[]
      */
@@ -133,7 +133,7 @@ final class Route
     }
 
     /**
-     * @interal
+     * @internal
      *
      * @param array{0: class-string, 1: string}|class-string|string $controller
      * @param string[]                                              $methods

--- a/src/Snicco/Component/http-routing/src/Routing/Route/RouteCollection.php
+++ b/src/Snicco/Component/http-routing/src/Routing/Route/RouteCollection.php
@@ -15,7 +15,7 @@ use function count;
  * @psalm-immutable
  *
  * @psalm-internal Snicco\Component\HttpRouting
- * @interal
+ * @internal
  */
 final class RouteCollection implements Routes
 {

--- a/src/Snicco/Component/http-routing/src/Routing/Route/SerializedRouteCollection.php
+++ b/src/Snicco/Component/http-routing/src/Routing/Route/SerializedRouteCollection.php
@@ -19,7 +19,7 @@ use function unserialize;
  * @psalm-external-mutation-free
  *
  * @psalm-internal Snicco\Component\HttpRouting
- * @interal
+ * @internal
  */
 final class SerializedRouteCollection implements Routes
 {

--- a/src/Snicco/Component/http-routing/src/Routing/RoutingConfigurator/Configurator.php
+++ b/src/Snicco/Component/http-routing/src/Routing/RoutingConfigurator/Configurator.php
@@ -29,7 +29,7 @@ use function is_string;
 use function trim;
 
 /**
- * @interal
+ * @internal
  *
  * @psalm-internal Snicco\Component\HttpRouting
  */

--- a/src/Snicco/Component/http-routing/src/Routing/RoutingConfigurator/RouteGroup.php
+++ b/src/Snicco/Component/http-routing/src/Routing/RoutingConfigurator/RouteGroup.php
@@ -13,7 +13,7 @@ use function trim;
 /**
  * @psalm-immutable
  *
- * @interal
+ * @internal
  * @psalm-internal Snicco\Component\HttpRouting
  */
 final class RouteGroup

--- a/src/Snicco/Component/http-routing/src/Routing/UrlGenerator/Generator.php
+++ b/src/Snicco/Component/http-routing/src/Routing/UrlGenerator/Generator.php
@@ -27,7 +27,7 @@ use function strpos;
 use function trim;
 
 /**
- * @interal
+ * @internal
  * @psalm-internal Snicco\Component\HttpRouting
  */
 final class Generator implements UrlGenerator

--- a/src/Snicco/Component/http-routing/src/Routing/UrlGenerator/LazyGenerator.php
+++ b/src/Snicco/Component/http-routing/src/Routing/UrlGenerator/LazyGenerator.php
@@ -7,7 +7,7 @@ namespace Snicco\Component\HttpRouting\Routing\UrlGenerator;
 use Closure;
 
 /**
- * @interal
+ * @internal
  * @psalm-internal Snicco\Component\HttpRouting
  */
 final class LazyGenerator implements UrlGenerator

--- a/src/Snicco/Component/http-routing/src/Routing/UrlMatcher/AdminRouteMatcher.php
+++ b/src/Snicco/Component/http-routing/src/Routing/UrlMatcher/AdminRouteMatcher.php
@@ -8,7 +8,7 @@ use Snicco\Component\HttpRouting\Http\Psr7\Request;
 use Snicco\Component\HttpRouting\Routing\Admin\AdminArea;
 
 /**
- * @interal
+ * @internal
  * @psalm-internal Snicco\Component\HttpRouting
  */
 final class AdminRouteMatcher implements UrlMatcher

--- a/src/Snicco/Component/http-routing/src/Routing/UrlMatcher/FastRouteDispatcher.php
+++ b/src/Snicco/Component/http-routing/src/Routing/UrlMatcher/FastRouteDispatcher.php
@@ -71,7 +71,7 @@ use function preg_match;
  * {@see \FastRoute\DataGenerator\GroupCountBased}
  * https://github.com/nikic/FastRoute/blob/v1.3.0/src/DataGenerator/GroupCountBased.php.
  *
- * @interal
+ * @internal
  * @psalm-internal Snicco\Component\HttpRouting
  */
 final class FastRouteDispatcher implements UrlMatcher

--- a/src/Snicco/Component/http-routing/src/Routing/UrlMatcher/FastRouteSyntaxConverter.php
+++ b/src/Snicco/Component/http-routing/src/Routing/UrlMatcher/FastRouteSyntaxConverter.php
@@ -18,7 +18,7 @@ use function str_replace;
 use function strlen;
 
 /**
- * @interal
+ * @internal
  *
  * @psalm-immutable
  * @psalm-internal Snicco\Component\HttpRouting

--- a/src/Snicco/Component/http-routing/tests/HttpRunnerTestCase.php
+++ b/src/Snicco/Component/http-routing/tests/HttpRunnerTestCase.php
@@ -45,7 +45,7 @@ use function array_merge;
 use function call_user_func;
 
 /**
- * @interal
+ * @internal
  */
 abstract class HttpRunnerTestCase extends TestCase
 {

--- a/src/Snicco/Component/http-routing/tests/Routing/Admin/AdminRoutesTest.php
+++ b/src/Snicco/Component/http-routing/tests/Routing/Admin/AdminRoutesTest.php
@@ -187,7 +187,7 @@ final class AdminRoutesTest extends HttpRunnerTestCase
     /**
      * @test
      */
-    public function admin_routes_do_not_match_for_non_admin_requests_that_have_the_same_rewritten_url_but_are_not_loaded_from_withing_the_admin_dashboard(
+    public function admin_routes_do_not_match_for_non_admin_requests_that_have_the_same_rewritten_url_but_are_not_loaded_from_within_the_admin_dashboard(
         ): void {
         $this->adminRouting(function (AdminRoutingConfigurator $configurator): void {
             $configurator->page('r1', 'options.php/foo', RoutingTestController::class, [], );

--- a/src/Snicco/Component/http-routing/tests/fixtures/NullErrorHandler.php
+++ b/src/Snicco/Component/http-routing/tests/fixtures/NullErrorHandler.php
@@ -10,7 +10,7 @@ use Snicco\Component\Psr7ErrorHandler\HttpErrorHandler;
 use Throwable;
 
 /**
- * @interal
+ * @internal
  *
  * @psalm-internal Snicco\Component\HttpRouting
  */

--- a/src/Snicco/Component/kernel/src/Configuration/ConfigLoader.php
+++ b/src/Snicco/Component/kernel/src/Configuration/ConfigLoader.php
@@ -14,7 +14,7 @@ use function pathinfo;
 use const PATHINFO_FILENAME;
 
 /**
- * @interal
+ * @internal
  * @psalm-internal Snicco\Component\Kernel
  */
 final class ConfigLoader

--- a/src/Snicco/Component/kernel/tests/KernelBootstrappersTest.php
+++ b/src/Snicco/Component/kernel/tests/KernelBootstrappersTest.php
@@ -96,7 +96,7 @@ final class KernelBootstrappersTest extends TestCase
             Directories::fromDefaults($this->fixtures_dir),
             new FixedConfigCache([
                 'kernel' => [
-                    'bootstrappers' => [BootstrapperWithExceptionInBoostrap::class],
+                    'bootstrappers' => [BootstrapperWithExceptionInBootstrap::class],
                     'bundles' => [],
                 ],
             ])
@@ -215,7 +215,7 @@ final class Bootstrap2 implements Bootstrapper
     }
 }
 
-final class BootstrapperWithExceptionInBoostrap implements Bootstrapper
+final class BootstrapperWithExceptionInBootstrap implements Bootstrapper
 {
     public function shouldRun(Environment $env): bool
     {

--- a/src/Snicco/Component/kernel/tests/helpers/CleanDirs.php
+++ b/src/Snicco/Component/kernel/tests/helpers/CleanDirs.php
@@ -10,7 +10,7 @@ use SplFileInfo;
 use function unlink;
 
 /**
- * @interal
+ * @internal
  */
 trait CleanDirs
 {

--- a/src/Snicco/Component/session/src/ReadWriteSession.php
+++ b/src/Snicco/Component/session/src/ReadWriteSession.php
@@ -54,7 +54,7 @@ final class ReadWriteSession implements Session
     private array $stored_events = [];
 
     /**
-     * @interal Sessions MUST only be started from a {@see SessionManagerInterface}
+     * @internal Sessions MUST only be started from a {@see SessionManagerInterface}
      *
      * @param mixed[] $data
      */
@@ -413,7 +413,7 @@ final class ReadWriteSession implements Session
     }
 
     /**
-     * @interal
+     * @internal
      */
     public function isDirty(): bool
     {

--- a/src/Snicco/Component/session/src/ValueObject/CookiePool.php
+++ b/src/Snicco/Component/session/src/ValueObject/CookiePool.php
@@ -28,7 +28,7 @@ final class CookiePool
     }
 
     /**
-     * @interal
+     * @internal
      * @psalm-internal Snicco\Component\Session
      */
     public function has(string $cookie_name): bool
@@ -37,7 +37,7 @@ final class CookiePool
     }
 
     /**
-     * @interal
+     * @internal
      * @psalm-internal Snicco\Component\Session
      */
     public function get(string $cookie_name): ?string

--- a/src/Snicco/Component/session/src/ValueObject/SessionConfig.php
+++ b/src/Snicco/Component/session/src/ValueObject/SessionConfig.php
@@ -202,7 +202,7 @@ final class SessionConfig
     }
 
     /**
-     * @interal
+     * @internal
      */
     public function gcLottery(): SessionLottery
     {

--- a/src/Snicco/Component/session/src/ValueObject/SessionLottery.php
+++ b/src/Snicco/Component/session/src/ValueObject/SessionLottery.php
@@ -10,7 +10,7 @@ use LogicException;
 use function random_int;
 
 /**
- * @interal
+ * @internal
  * @psalm-internal Snicco\Component\Session
  */
 final class SessionLottery

--- a/src/Snicco/Component/signed-url/README.md
+++ b/src/Snicco/Component/signed-url/README.md
@@ -214,7 +214,7 @@ $storage = new \Snicco\Component\SignedUrl\Storage\SessionStorage($arr);
 The [`NullStorage`](src/Storage/NullStorage.php) does nothing. No signed-urls will be stored
 and no usage limits are enforced. Use this only if your signed-urls should be valid any number of times before expiring.
 
-Validity of a signed-url will be based solely on the correct signature and expriation timestamp.
+Validity of a signed-url will be based solely on the correct signature and expiration timestamp.
 
 ---
 

--- a/src/Snicco/Component/signed-url/src/HMAC.php
+++ b/src/Snicco/Component/signed-url/src/HMAC.php
@@ -21,7 +21,7 @@ final class HMAC
     }
 
     /**
-     * @interal
+     * @internal
      *
      * @psalm-internal Snicco\Component\SignedUrl
      */

--- a/src/Snicco/Component/signed-url/src/Secret.php
+++ b/src/Snicco/Component/signed-url/src/Secret.php
@@ -59,7 +59,7 @@ final class Secret
     }
 
     /**
-     * @interal
+     * @internal
      *
      * @psalm-suppress PossiblyUndefinedIntArrayOffset
      */

--- a/src/Snicco/Component/signed-url/src/UrlSigner.php
+++ b/src/Snicco/Component/signed-url/src/UrlSigner.php
@@ -72,7 +72,7 @@ final class UrlSigner
         $signature = Base64UrlSafe::encode($this->hasher->create($plain_text_signature));
 
         // We append the expires_at and signature timestamp to the path, so that it can be easily validated.
-        // If any of the plain text parts have been tampered validation wil fail.
+        // If any of the plain text parts have been tampered validation will fail.
         $path_with_query =
             $this->appendExpiryQueryParam($path_with_query, $expires_at)
             . '&'

--- a/src/Snicco/Middleware/default-headers/.gitattributes
+++ b/src/Snicco/Middleware/default-headers/.gitattributes
@@ -3,4 +3,4 @@
 phpunit.dist.xml export-ignore
 README.md export-ignore
 /tests export-ignore
-.github export-ingore
+.github export-ignore

--- a/src/Snicco/Middleware/method-override/README.md
+++ b/src/Snicco/Middleware/method-override/README.md
@@ -8,7 +8,7 @@
 ![PHP-Versions](https://img.shields.io/badge/PHP-%5E7.4%7C%5E8.0%7C%5E8.1-blue)
 
 A middleware for the [`snicco/http-routing`](https://github.com/snicco/http-routing) component that allows you
-to override the HTTP method for `POST` requests to either `PATCH|PUT|DELELE` based on the post body.
+to override the HTTP method for `POST` requests to either `PATCH|PUT|DELETE` based on the post body.
 
 
 ## Installation
@@ -24,7 +24,7 @@ This middleware should be added for **globally** in the `MiddlewareResolver`.
 To allow overwriting the HTTP method, either a `_method` must be present in the request body or the `X-HTTP-Method-Override`
 header must be present.
 
-Overwriting the HTTP method only works for `POST` methods. Valid values are `PATCH|PUT|DELELE`.
+Overwriting the HTTP method only works for `POST` methods. Valid values are `PATCH|PUT|DELETE`.
 
 ## Contributing
 

--- a/src/Snicco/Middleware/method-override/tests/MethodOverrideTest.php
+++ b/src/Snicco/Middleware/method-override/tests/MethodOverrideTest.php
@@ -76,7 +76,7 @@ final class MethodOverrideTest extends MiddlewareTestCase
     /**
      * @test
      */
-    public function a_post_request_without_any_overrite_stays_untouched(): void
+    public function a_post_request_without_any_override_stays_untouched(): void
     {
         $request = $this->frontendRequest('/', [], 'POST')->withParsedBody([
             'foo' => 'bar',

--- a/src/Snicco/Middleware/open-redirect-protection/README.md
+++ b/src/Snicco/Middleware/open-redirect-protection/README.md
@@ -13,7 +13,7 @@ It inspects the `location` header of the response and disallows any redirects to
 external hosts.
 
 Instead, the user will be redirected to the configured "exit" page.
-The intended redirect location will be available in a `intented_redirect` query variable.
+The intended redirect location will be available in a `intended_redirect` query variable.
 
 ## Installation
 

--- a/src/Snicco/Middleware/wp-auth-only/README.md
+++ b/src/Snicco/Middleware/wp-auth-only/README.md
@@ -8,7 +8,7 @@
 ![PHP-Versions](https://img.shields.io/badge/PHP-%5E7.4%7C%5E8.0%7C%5E8.1-blue)
 
 This middleware checks if a **WordPress** user is logged in
-and will throw a `401 HTTPExcetion` if that's not the case.
+and will throw a `401 HTTPException` if that's not the case.
 
 ## Installation
 

--- a/src/Snicco/Middleware/wp-capability/README.md
+++ b/src/Snicco/Middleware/wp-capability/README.md
@@ -8,7 +8,7 @@
 ![PHP-Versions](https://img.shields.io/badge/PHP-%5E7.4%7C%5E8.0%7C%5E8.1-blue)
 
 This middleware checks if the currently logged-in **WordPress** user has a specified capability
-and will throw a `403 HTTPExcetion` if that's not the case.
+and will throw a `403 HTTPException` if that's not the case.
 
 ## Installation
 

--- a/src/Snicco/Middleware/wp-guests-only/README.md
+++ b/src/Snicco/Middleware/wp-guests-only/README.md
@@ -18,7 +18,7 @@ composer require snicco/wp-guest-only-middleware
 
 This middleware should be added on a per-route basis.
 
-If a logged a user is logged in this middleware will try to redirect to a route named `dashbaord` if it exists.
+If a logged a user is logged in this middleware will try to redirect to a route named `dashboard` if it exists.
 Otherwise, the user is redirect to the homepage.
 
 Optionally, a custom redirect path can be set by passing middleware arguments.

--- a/src/Snicco/Testing/better-wp-cli/src/Constraint/CommandIsSuccessful.php
+++ b/src/Snicco/Testing/better-wp-cli/src/Constraint/CommandIsSuccessful.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\Constraint\Constraint;
 use Snicco\Component\BetterWPCLI\Command;
 
 /**
- * @interal
+ * @internal
  *
  * @psalm-internal Snicco\Component\BetterWPCLI\Testing
  */

--- a/src/Snicco/Testing/better-wp-cli/src/Constraint/InStream.php
+++ b/src/Snicco/Testing/better-wp-cli/src/Constraint/InStream.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\Constraint\Constraint;
 use function strpos;
 
 /**
- * @interal
+ * @internal
  *
  * @psalm-internal Snicco\Component\BetterWPCLI\Testing
  */

--- a/src/Snicco/Testing/better-wp-cli/src/Constraint/NotInStream.php
+++ b/src/Snicco/Testing/better-wp-cli/src/Constraint/NotInStream.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\Constraint\Constraint;
 use function strpos;
 
 /**
- * @interal
+ * @internal
  *
  * @psalm-internal Snicco\Component\BetterWPCLI\Testing
  */

--- a/src/Snicco/Testing/better-wp-cli/src/Constraint/StatusCode.php
+++ b/src/Snicco/Testing/better-wp-cli/src/Constraint/StatusCode.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\Constraint\Constraint;
 use function sprintf;
 
 /**
- * @interal
+ * @internal
  *
  * @psalm-internal Snicco\Component\BetterWPCLI\Testing
  */

--- a/src/Snicco/Testing/better-wp-cli/src/TestOutput.php
+++ b/src/Snicco/Testing/better-wp-cli/src/TestOutput.php
@@ -9,7 +9,7 @@ use Snicco\Component\BetterWPCLI\Output\Output;
 use Snicco\Component\BetterWPCLI\Output\OutputWithVerbosity;
 
 /**
- * @interal
+ * @internal
  *
  * @psalm-internal Snicco\Component\BetterWPCLI\Testing
  */

--- a/src/Snicco/Testing/better-wp-cli/tests/unit/CommandTesterTest.php
+++ b/src/Snicco/Testing/better-wp-cli/tests/unit/CommandTesterTest.php
@@ -62,7 +62,7 @@ final class CommandTesterTest extends TestCase
     /**
      * @test
      */
-    public function that_asser_status_code_can_fail(): void
+    public function that_assert_status_code_can_fail(): void
     {
         $tester = new CommandTester(new FooCommand(12));
 


### PR DESCRIPTION
Found few (2⁷) misspellings.

@calvinalkan Please add a commit handling deprecation.

https://github.com/crate-ci/typos