### PR TITLE
fix(*): remove renamed/deleted files before splitting the package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ _output
 node_modules
 package-lock.json
 wp
+idea
 
 # temporary
 /bin/change-packages


### PR DESCRIPTION
(Partially cherry picked from commit 9df6f27e3b77c00c1e95afbee96631c589636399)

Our split-package.php script had a bug, where instead of `rsync`, it used `cp`, which meant that if a file has been deleted in the monorepo, that deletion was never reflected into the split package.